### PR TITLE
Enable company switching on mobile config

### DIFF
--- a/src/components/config/mobile/index.tsx
+++ b/src/components/config/mobile/index.tsx
@@ -21,6 +21,7 @@ import {
   styled,
   alpha,
   Select,
+  MenuItem,
   ToggleButton,
   ToggleButtonGroup
 } from "@mui/material";
@@ -49,7 +50,14 @@ const GlassCard = styled(Card)(({ theme }) => ({
   marginBottom: theme.spacing(2),
 }));
 
-const MobileConfig: React.FC<{ activeCompany: string; userData: any; modulesUpdating: boolean; setModulesUpdating: (b: boolean) => void }> = ({ activeCompany, userData, modulesUpdating, setModulesUpdating }) => {
+const MobileConfig: React.FC<{
+  activeCompany: string;
+  userData: any;
+  modulesUpdating: boolean;
+  setModulesUpdating: (b: boolean) => void;
+  companies: any[];
+  setActiveCompany: (id: string) => void;
+}> = ({ activeCompany, userData, modulesUpdating, setModulesUpdating, companies = [], setActiveCompany }) => {
   const theme = useTheme();
   const { enqueueSnackbar } = useSnackbar();
   const { t } = useTranslation();
@@ -229,6 +237,19 @@ const MobileConfig: React.FC<{ activeCompany: string; userData: any; modulesUpda
   );
   const renderCompany = () => (
     <Box sx={{ p:2, overflowY:'auto', flexGrow:1 }}>
+      <Select
+        fullWidth
+        size="small"
+        value={activeCompany || ''}
+        onChange={(e) => setActiveCompany(e.target.value as string)}
+        sx={{ mb:2 }}
+      >
+        {companies.map((comp) => (
+          <MenuItem key={comp.id} value={comp.id}>
+            {comp.name}
+          </MenuItem>
+        ))}
+      </Select>
       <GlassCard>
         <CardContent>
           <Stack direction="row" alignItems="center" spacing={2} sx={{ mb:2 }}>

--- a/src/pages/Dashboard/dashboard.tsx
+++ b/src/pages/Dashboard/dashboard.tsx
@@ -125,7 +125,23 @@ useEffect(() => {
         {activeModuleName === 'orders' && <Command activeCompany={activeCompany} userData={userData} />}
         {activeModuleName === 'online' && <Tracking userData={userData} activeCompany={activeCompany} />}
         {activeModuleName === 'marketing' ? window.outerWidth > 600 ? <MarketingDashboard activeCompany={activeCompany} /> : <MobileMarketingDashboard activeCompany={activeCompany} />  : ''}
-        {activeModuleName === 'config' && activeCompany ? window.outerWidth > 600 ? <Config userData={userData} activeCompany={activeCompany} modulesUpdating={modulesUpdating} setModulesUpdating={setModulesUpdating} /> : <MobileConfig userData={userData} activeCompany={activeCompany} modulesUpdating={modulesUpdating} setModulesUpdating={setModulesUpdating} /> : ''}
+        {activeModuleName === 'config' && activeCompany ? window.outerWidth > 600 ? (
+          <Config
+            userData={userData}
+            activeCompany={activeCompany}
+            modulesUpdating={modulesUpdating}
+            setModulesUpdating={setModulesUpdating}
+          />
+        ) : (
+          <MobileConfig
+            userData={userData}
+            activeCompany={activeCompany}
+            modulesUpdating={modulesUpdating}
+            setModulesUpdating={setModulesUpdating}
+            companies={companies}
+            setActiveCompany={changeActiveCompany}
+          />
+        ) : ''}
         {activeModuleName === 'integration' && <Integrations />}
       </DashboardContainerShowed>
     </DashboardContainer>


### PR DESCRIPTION
## Summary
- allow selecting active company in mobile config screen
- pass companies and change function from Dashboard

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684751dd884883218a5db57ff78f4b38