### PR TITLE
Add CRM lead and segmentation services

### DIFF
--- a/src/services/crm.service.ts
+++ b/src/services/crm.service.ts
@@ -1,8 +1,21 @@
 import http from './http-business.ts';
 
 class CrmService {
-    static getCrm(copmanyId) {
-        return http.get(`/crm/${copmanyId}`);
-    }
+  static getCrm(companyId: string) {
+    return http.get(`/crm/${companyId}`);
+  }
+
+  static createCustomer(companyId: string, data: any) {
+    return http.post('/crm', { ...data, companyId });
+  }
+
+  static updateCustomer(id: string, data: any) {
+    return http.patch('/crm', { ...data, id });
+  }
+
+  static deleteCustomer(id: string) {
+    return http.delete(`/crm/${id}`);
+  }
 }
+
 export default CrmService;

--- a/src/services/segmentation.service.ts
+++ b/src/services/segmentation.service.ts
@@ -1,0 +1,21 @@
+import http from './http-business.ts';
+
+class SegmentationService {
+  static getSegments(companyId: string) {
+    return http.get(`/crm/segments/${companyId}`);
+  }
+
+  static createSegment(data: any) {
+    return http.post('/crm/segments', data);
+  }
+
+  static updateSegment(id: string, data: any) {
+    return http.patch(`/crm/segments/${id}`, data);
+  }
+
+  static deleteSegment(id: string) {
+    return http.delete(`/crm/segments/${id}`);
+  }
+}
+
+export default SegmentationService;


### PR DESCRIPTION
## Summary
- implement `segmentation.service` for CRUD actions
- extend `crm.service` to handle lead management
- connect CRM page to API services for segments and leads
- enable the UI buttons for creating segments and leads

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684836fcc8e883219903ff4204fbc6a0