### PR TITLE
Fix token persistence on refresh

### DIFF
--- a/src/components/auth/index.tsx
+++ b/src/components/auth/index.tsx
@@ -174,11 +174,11 @@ const Auth = () => {
       .then((res) => {
         if (res.data) {
           if(action === AllInOneService.create){
-            setPendingToken(res.data);
+            setPendingToken(res.data?.accessToken || res.data);
             setShowPlanSelection(true);
             return;
           }
-          setToken(res.data)
+          setToken(res.data?.accessToken || res.data)
         }
         setLoading(false);
       })
@@ -209,7 +209,7 @@ const Auth = () => {
           })
             .then((data) => {
               if (data.data) {
-                setToken(data.data);
+                setToken(data.data?.accessToken || data.data);
               }
             })
             .catch((err) => {
@@ -220,7 +220,7 @@ const Auth = () => {
           AllInOneService.get({ email, password: sub })
             .then((data) => {
               if (data.data) {
-                setToken(data.data);
+                setToken(data.data?.accessToken || data.data);
               }
             })
             .catch((err) => {

--- a/src/components/auth/mobile/index.tsx
+++ b/src/components/auth/mobile/index.tsx
@@ -173,11 +173,11 @@ const MobileAuth = () => {
       .then((res) => {
         if (res.data) {
           if(action === AllInOneService.create){
-            setPendingToken(res.data);
+            setPendingToken(res.data?.accessToken || res.data);
             setShowPlanSelection(true);
             return;
           }
-          setToken(res.data)
+          setToken(res.data?.accessToken || res.data)
         }
         setLoading(false);
       })
@@ -208,7 +208,7 @@ const MobileAuth = () => {
           })
             .then((data) => {
               if (data.data) {
-                setToken(data.data);
+                setToken(data.data?.accessToken || data.data);
               }
             })
             .catch((err) => {
@@ -219,7 +219,7 @@ const MobileAuth = () => {
           AllInOneService.get({ email, password: sub })
             .then((data) => {
               if (data.data) {
-                setToken(data.data);
+                setToken(data.data?.accessToken || data.data);
               }
             })
             .catch((err) => {

--- a/src/components/auth/payments/index.tsx
+++ b/src/components/auth/payments/index.tsx
@@ -73,7 +73,8 @@ const CheckoutForm = ({ selectedPlan, onClose, pendingToken, userEmail }) => {
   }, [token, navigate]);
 
   useEffect(()=>{
-    AllInOneService.getUserByToken(pendingToken)
+    const tokenValue = pendingToken?.accessToken || pendingToken;
+    AllInOneService.getUserByToken(tokenValue)
       .then((res) => setUserId(res.data._id))
   },[pendingToken])
 

--- a/src/pages/Dashboard/dashboard.tsx
+++ b/src/pages/Dashboard/dashboard.tsx
@@ -41,7 +41,7 @@ useEffect(() => {
   if (!token || userData) return;
 
   const interval = setInterval(() => {
-    AllInOneService.getUserByToken(token)
+    AllInOneService.getUserByToken(token?.accessToken || token)
       .then((res) => {
         if (res?.data) {
           setUserData(res.data);
@@ -57,7 +57,7 @@ useEffect(() => {
 
   useEffect(() => {
   if (!token) return;
-  AllInOneService.getUserByToken(token)
+  AllInOneService.getUserByToken(token?.accessToken || token)
     .then(async ({ data: user }) => {
       setUserData(user);
       if (hasNoCompanies) {

--- a/src/services/all-in-one.service.ts
+++ b/src/services/all-in-one.service.ts
@@ -8,8 +8,9 @@ class AllInOneService {
 		return http.post('https://all-in-one-system-cfe0c681a225.herokuapp.com/user/sign-up', data);
 	}
     static getUserByToken(data: any) {
-		return http.get(`https://all-in-one-system-cfe0c681a225.herokuapp.com/user/token/${data}`);
-	}
+                const tokenValue = data?.accessToken || data;
+                return http.get(`https://all-in-one-system-cfe0c681a225.herokuapp.com/user/token/${tokenValue}`);
+        }
 	static delete(data: any) {
 		return http.delete(`//${data}`);
 	}

--- a/src/services/http-all-in-one.ts
+++ b/src/services/http-all-in-one.ts
@@ -12,13 +12,17 @@ const axiosInstance = axios.create({
 
 // Add a request interceptor
 axiosInstance.interceptors.request.use(
-	(config: any) => {
-		const accessToken = getStorageValue('accessToken', null);
-		if (accessToken) {
-			if (config.headers)
-				config.headers.Authorization = `Bearer ${accessToken}`;
-		}
-		return config;
+        (config: any) => {
+                const stored = getStorageValue('accessToken', null);
+                let accessToken = stored;
+                if (stored && typeof stored === 'object' && stored.accessToken) {
+                        accessToken = stored.accessToken;
+                }
+                if (accessToken) {
+                        if (config.headers)
+                                config.headers.Authorization = `Bearer ${accessToken}`;
+                }
+                return config;
 	},
 	(error) => Promise.reject(error)
 );

--- a/src/services/http-business.ts
+++ b/src/services/http-business.ts
@@ -15,13 +15,17 @@ const axiosInstance = axios.create({
 
 // Add a request interceptor
 axiosInstance.interceptors.request.use(
-	(config: any) => {
-		const accessToken = getStorageValue('accessToken', null);
-		if (accessToken) {
-			if (config.headers)
-				config.headers.Authorization = `Bearer ${accessToken}`;
-		}
-		return config;
+        (config: any) => {
+                const stored = getStorageValue('accessToken', null);
+                let accessToken = stored;
+                if (stored && typeof stored === 'object' && stored.accessToken) {
+                        accessToken = stored.accessToken;
+                }
+                if (accessToken) {
+                        if (config.headers)
+                                config.headers.Authorization = `Bearer ${accessToken}`;
+                }
+                return config;
 	},
 	(error) => Promise.reject(error)
 );


### PR DESCRIPTION
## Summary
- handle object token storage across login screens
- fetch user data correctly when refreshing dashboard
- ensure API calls send proper Authorization header
- support pending token usage in payment flow

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec444c6548321adc8713d76ec1621