### PR TITLE
Update UI to brand colors

### DIFF
--- a/src/components/calendar/styles.ts
+++ b/src/components/calendar/styles.ts
@@ -31,16 +31,16 @@ export const Header = styled.div`
   }
 
   button {
-    background-color: #4caf50;
-    color: white;
+    background-color: #578acd;
+    color: #fff;
     border: none;
     padding: 10px 20px;
-    border-radius: 5px;
+    border-radius: 8px;
     cursor: pointer;
     transition: background-color 0.3s ease;
 
     &:hover {
-      background-color: #45a049;
+      background-color: #38639a;
     }
   }
 
@@ -109,16 +109,16 @@ export const ViewSwitcher = styled.div`
   margin-bottom: 20px;
 
   button {
-    background-color: #2196f3;
-    color: white;
+    background-color: #578acd;
+    color: #fff;
     border: none;
     padding: 10px;
-    border-radius: 5px;
+    border-radius: 8px;
     cursor: pointer;
     margin-right: 10px;
 
     &:hover {
-      background-color: #1976d2;
+      background-color: #38639a;
     }
   }
 
@@ -134,12 +134,12 @@ export const ViewSwitcher = styled.div`
 `;
 
 export const Event = styled.div`
-  background-color: #5a86b5;
+  background-color: #578acd;
   padding: 2px 5px;
   margin-top: 5px;
-  border-radius: 3px;
+  border-radius: 8px;
   font-size: 0.75em;
-  color: white;
+  color: #fff;
   font-weight: 500;
 
   @media (max-width: 768px) {

--- a/src/components/marketing/automation/index.tsx
+++ b/src/components/marketing/automation/index.tsx
@@ -29,6 +29,10 @@ import { EmptyStateContainer, EmptyStateTitle, EmptyStateDescription } from "../
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import Skeleton from '@mui/material/Skeleton';
 
+const primaryColor = '#578acd';
+const textColor = '#fff';
+const rounded = 8;
+
 const AutomationDashboard = ({ activeCompany, setModule }) => {
   const [automations, setAutomations] = useState([]);
   const [isCreating, setIsCreating] = useState(false);
@@ -120,11 +124,11 @@ const AutomationDashboard = ({ activeCompany, setModule }) => {
       </EmptyStateDescription>
       <Button
         variant="contained"
-        color="primary"
         onClick={() => setIsCreating(true)}
         size={isMobile ? "small" : "medium"}
         fullWidth={isMobile}
-        sx={{ mt: 2 }}
+        sx={{ mt: 2, backgroundColor: primaryColor, color: textColor, borderRadius: rounded,
+            '&:hover': { backgroundColor: '#4c7fb5' } }}
       >
         {t('marketing.automationTable.createAutomation')}
       </Button>
@@ -132,7 +136,7 @@ const AutomationDashboard = ({ activeCompany, setModule }) => {
   );
 
   const renderLoadingSkeleton = () => (
-    <Card sx={{ mt: 3 }}>
+    <Card sx={{ mt: 3, borderRadius: rounded }}>
       <CardContent>
         <TableContainer>
           <Table>
@@ -201,7 +205,7 @@ const AutomationDashboard = ({ activeCompany, setModule }) => {
   );
 
   const renderTable = () => (
-    <Card sx={{ mt: 3, overflowX: 'auto' }}>
+    <Card sx={{ mt: 3, overflowX: 'auto', borderRadius: rounded }}>
       <CardContent>
         <TableContainer component={Paper} elevation={0}>
           <Table size={isMobile ? "small" : "medium"} stickyHeader>
@@ -255,10 +259,10 @@ const AutomationDashboard = ({ activeCompany, setModule }) => {
         <Button
           variant="contained"
           startIcon={<Add />}
-          color="primary"
           onClick={() => setIsCreating(true)}
           size={isMobile ? "small" : "medium"}
-          sx={{ ml: isMobile ? 1 : 3 }}
+          sx={{ ml: isMobile ? 1 : 3, backgroundColor: primaryColor, color: textColor, borderRadius: rounded,
+            '&:hover': { backgroundColor: '#4c7fb5' } }}
           fullWidth={isMobile}
         >
           {t("marketing.automationTable.newAutomation")}

--- a/src/components/marketing/capture-pages/index.tsx
+++ b/src/components/marketing/capture-pages/index.tsx
@@ -30,6 +30,10 @@ import LeadsService from "../../../services/leads.service.ts";
 import { useSnackbar } from "notistack";
 import ProgressService from "../../../services/progress.service.ts";
 
+const primaryColor = '#578acd';
+const textColor = '#fff';
+const rounded = 12;
+
 // Importações para o Chart.js
 import { Bar } from "react-chartjs-2";
 import {
@@ -330,7 +334,7 @@ const LandingPageCard: React.FC<{
   const { t } = useTranslation();
   return (
     <Grid item xs={12} sm={6} md={4} key={page.id}>
-      <Card>
+      <Card sx={{ borderRadius: rounded }}>
         {page.screenshotUrl ? (
           <img
             src={page.screenshotUrl}
@@ -376,13 +380,13 @@ const LandingPageCard: React.FC<{
           </Typography>
         </CardContent>
         <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "flex-start", margin: "8px" }}>
-          <Button size="small" onClick={() => onViewDetails(page)}>
+          <Button size="small" onClick={() => onViewDetails(page)} sx={{ backgroundColor: primaryColor, color: textColor, borderRadius: rounded, '&:hover': { backgroundColor: '#4c7fb5' } }}>
             {t("marketing.capturePages.viewDetails")}
           </Button>
-          <Button sx={{marginLeft:'-12px'}} size="small" onClick={() => onEdit(page)}>
+          <Button sx={{marginLeft:'-12px', backgroundColor: primaryColor, color: textColor, borderRadius: rounded, '&:hover': { backgroundColor: '#4c7fb5' } }} size="small" onClick={() => onEdit(page)}>
             {t("marketing.capturePages.editPage")} Landing Page
           </Button>
-          <Button size="small" onClick={() => onViewWebsite(page)}>
+          <Button size="small" onClick={() => onViewWebsite(page)} sx={{ backgroundColor: primaryColor, color: textColor, borderRadius: rounded, '&:hover': { backgroundColor: '#4c7fb5' } }}>
             {t("marketing.capturePages.viewLandingPage")}
           </Button>
         </Box>
@@ -399,7 +403,7 @@ const FormCard: React.FC<{
   const { t } = useTranslation();
   return (
     <Grid item xs={12} sm={6} md={4} key={form.id}>
-      <Card>
+      <Card sx={{ borderRadius: rounded }}>
         <CardContent>
           <Typography variant="h6">{form.title}</Typography>
           <Typography variant="body2" color="textSecondary">
@@ -411,10 +415,10 @@ const FormCard: React.FC<{
           <FormSubmissionsChart submissions={form.formlead} />
         </CardContent>
         <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "flex-start", margin: "8px" }}>
-          <Button size="small" onClick={() => onViewDetails(form)}>
+          <Button size="small" onClick={() => onViewDetails(form)} sx={{ backgroundColor: primaryColor, color: textColor, borderRadius: rounded, '&:hover': { backgroundColor: '#4c7fb5' } }}>
             {t("marketing.capturePages.viewDetails")}
           </Button>
-          <Button size="small" onClick={() => onViewWebsite(form)}>
+          <Button size="small" onClick={() => onViewWebsite(form)} sx={{ backgroundColor: primaryColor, color: textColor, borderRadius: rounded, '&:hover': { backgroundColor: '#4c7fb5' } }}>
             {t("marketing.capturePages.viewForm")}
           </Button>
         </Box>
@@ -812,8 +816,8 @@ const TemplateDialog: React.FC<{
                     />
                     <Button
                       variant="contained"
-                      color="primary"
-                      sx={{ height: '55px', borderTopLeftRadius:'0px', borderBottomLeftRadius:'0px', whiteSpace: 'nowrap', mt: '4px', marginLeft:'-8px' }}
+                      sx={{ height: '55px', borderTopLeftRadius:'0px', borderBottomLeftRadius:'0px', whiteSpace: 'nowrap', mt: '4px', marginLeft:'-8px', backgroundColor: primaryColor, color: textColor,
+                        '&:hover': { backgroundColor: '#4c7fb5' } }}
                       onClick={handleAddCustomSection}
                     >
                       <PlusCircle size={30}/>
@@ -826,11 +830,11 @@ const TemplateDialog: React.FC<{
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>{t("common.cancel")}</Button>
+        <Button onClick={onClose} sx={{ color: primaryColor }}>{t("common.cancel")}</Button>
         <Button
           variant="contained"
-          color="primary"
           disabled={newPage.title === "" || (mode === "choose" && !selectedTemplate) || generating}
+          sx={{ backgroundColor: primaryColor, color: textColor, '&:hover': { backgroundColor: '#4c7fb5' } }}
           onClick={async () => {
             if (mode === "choose") {
               setPreviewUrl(`https://roktune.duckdns.org/landing-pages/preview?type=${selectedTemplate.type}&companyId=${activeCompany}&title=${newPage.title}`);
@@ -920,6 +924,7 @@ const PreviewDialog: React.FC<{
         disabled={creatingLandingpage}
         variant="contained"
         startIcon={creatingLandingpage ? <CircularProgress size={20} /> : null}
+        sx={{ backgroundColor: primaryColor, color: textColor, '&:hover': { backgroundColor: '#4c7fb5' } }}
       >
         {creatingLandingpage ? '' : t("marketing.previewDialog.createLandingPage")}
       </Button>
@@ -951,7 +956,7 @@ const DetailsDialog: React.FC<{
         )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onClose}>{t("common.close")}</Button>
+        <Button onClick={onClose} sx={{ color: primaryColor }}>{t("common.close")}</Button>
       </DialogActions>
     </Dialog>
   );
@@ -986,7 +991,7 @@ const EditDialog: React.FC<{
             {t("marketing.capturePages.deletePage")}
           </Button>
         )}
-        <Button onClick={onClose}>{t("common.close")}</Button>
+        <Button onClick={onClose} sx={{ color: primaryColor }}>{t("common.close")}</Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/marketing/crm/index.tsx
+++ b/src/components/marketing/crm/index.tsx
@@ -9,6 +9,10 @@ import dayjs from 'dayjs';
 import { Box, Typography } from '@mui/material';
 import { ArrowBackIos } from '@mui/icons-material';
 
+const primaryColor = '#578acd';
+const textColor = '#fff';
+const rounded = 12;
+
 // Tipos de dados
 interface Customer {
   id: string;
@@ -314,16 +318,16 @@ const CRMApp: React.FC = ({ activeCompany, setModule }) => {
         </Typography>
       </Box>
       <div style={{ display: 'flex', gap: 16, marginBottom: 24 }}>
-        <Card title={t('marketing.crm.totalCustomers')} style={{ flex: 1 }}>
+        <Card title={t('marketing.crm.totalCustomers')} style={{ flex: 1, borderRadius: rounded, backgroundColor: primaryColor, color: textColor }}>
           <h2>{metrics.totalCustomers}</h2>
         </Card>
-        <Card title={t('marketing.crm.activeCustomers')} style={{ flex: 1 }}>
+        <Card title={t('marketing.crm.activeCustomers')} style={{ flex: 1, borderRadius: rounded, backgroundColor: primaryColor, color: textColor }}>
           <h2>{metrics.activeCustomers}</h2>
         </Card>
-        <Card title={t('marketing.crm.totalValue')} style={{ flex: 1 }}>
+        <Card title={t('marketing.crm.totalValue')} style={{ flex: 1, borderRadius: rounded, backgroundColor: primaryColor, color: textColor }}>
           <h2>$ {metrics.totalValue.toLocaleString('pt-BR')}</h2>
         </Card>
-        <Card title={t('marketing.crm.averageValue')} style={{ flex: 1 }}>
+        <Card title={t('marketing.crm.averageValue')} style={{ flex: 1, borderRadius: rounded, backgroundColor: primaryColor, color: textColor }}>
           <h2>$ {metrics.avgValue.toLocaleString('pt-BR', { maximumFractionDigits: 2 })}</h2>
         </Card>
       </div>
@@ -350,6 +354,7 @@ const CRMApp: React.FC = ({ activeCompany, setModule }) => {
         <Button
           icon={<FilterOutlined />}
           onClick={handleCreateSegment}
+          style={{ backgroundColor: primaryColor, color: textColor, borderRadius: rounded, borderColor: primaryColor }}
         >
           {t('marketing.crm.createSegment')}
         </Button>
@@ -358,7 +363,7 @@ const CRMApp: React.FC = ({ activeCompany, setModule }) => {
           type="primary"
           icon={<PlusOutlined />}
           onClick={handleCreateCustomer}
-          style={{ marginLeft: 'auto' }}
+          style={{ marginLeft: 'auto', backgroundColor: primaryColor, color: textColor, borderRadius: rounded, borderColor: primaryColor }}
         >
           {t('marketing.crm.createCustomer')}
         </Button>
@@ -456,7 +461,7 @@ const CRMApp: React.FC = ({ activeCompany, setModule }) => {
           </Form.List>
 
           <Form.Item>
-            <Button type="primary" htmlType="submit">
+            <Button type="primary" htmlType="submit" style={{ backgroundColor: primaryColor, color: textColor, borderRadius: rounded, borderColor: primaryColor }}>
               Salvar Segmento
             </Button>
           </Form.Item>
@@ -561,7 +566,7 @@ const CRMApp: React.FC = ({ activeCompany, setModule }) => {
           )}
 
           <Form.Item>
-            <Button type="primary" htmlType="submit">
+            <Button type="primary" htmlType="submit" style={{ backgroundColor: primaryColor, color: textColor, borderRadius: rounded, borderColor: primaryColor }}>
               {currentCustomer ? 'Atualizar Cliente' : 'Adicionar Cliente'}
             </Button>
           </Form.Item>

--- a/src/components/products/styles.ts
+++ b/src/components/products/styles.ts
@@ -38,7 +38,7 @@ export const Input = styled.input`
     font-size: 16px;
     width: 88%;
     &:focus {
-        border-color: #007bff;
+        border-color: #578acd;
         outline: none;
     }
 `;
@@ -50,7 +50,7 @@ export const TextArea = styled.textarea`
     font-size: 16px;
     resize: none;
     &:focus {
-        border-color: #007bff;
+        border-color: #578acd;
         outline: none;
     }
 `;
@@ -61,7 +61,7 @@ export const Select = styled.select`
     border: 1px solid #ddd;
     font-size: 16px;
     &:focus {
-        border-color: #007bff;
+        border-color: #578acd;
         outline: none;
     }
 `;
@@ -70,7 +70,7 @@ export const Button = styled.button`
     padding: 10px;
     border-radius: 5px;
     border: none;
-    background-color: #007bff;
+    background-color: #578acd;
     color: white;
     font-size: 16px;
     cursor: pointer;
@@ -78,7 +78,7 @@ export const Button = styled.button`
     transition: background-color 0.3s;
 
     &:hover {
-        background-color: #0056b3;
+        background-color: #38639a;
     }
 `;
 
@@ -90,19 +90,19 @@ export const CancelButton = styled(Button)`
 `;
 
 export const FormButton = styled.button`
-  background-color: #4CAF50; // Green background
-  color: white; // White text
-  border: none; // No border
-  padding: 10px; // Padding
-  border-radius: 5px; // Rounded corners
-  cursor: pointer; // Pointer cursor on hover
-  font-size: 16px; // Font size
-  transition: background-color 0.3s; // Transition effect
+  background-color: #578acd;
+  color: #fff;
+  border: none;
+  padding: 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
+  transition: background-color 0.3s;
   width: 92%;
   margin-top:30px;
   margin-bottom:30px;
   &:hover {
-    background-color: #45a049; // Darker green on hover
+    background-color: #38639a;
   }
 `;
 
@@ -145,10 +145,10 @@ export const RemoveButton = styled.button`
 
 export const UploadButton = styled.label`
   display: inline-block;
-  background-color: #4CAF50;
-  color: white;
+  background-color: #578acd;
+  color: #fff;
   padding: 10px 20px;
-  border-radius: 5px;
+  border-radius: 8px;
   cursor: pointer;
   margin-top: 10px;
 `;
@@ -271,7 +271,7 @@ export const EmptyStateButton = styled.button`
     justify-content: center;
     padding: 10px 20px;
     margin: 10px 0;
-    background-color: #007bff;
+    background-color: #578acd;
     color: white;
     border: none;
     border-radius: 5px;
@@ -280,7 +280,7 @@ export const EmptyStateButton = styled.button`
     transition: background-color 0.3s ease;
 
     &:hover {
-        background-color: #0056b3;
+        background-color: #38639a;
     }
 
     @media (max-width: 768px) {

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -145,8 +145,8 @@ const Sidebar: React.FC<{
               props.activateModule(mainModule.key);
             }}
             style={{
-              backgroundColor: 'rgba(0, 168, 255, 0.1)',
-              borderLeft: '4px solid #00a8ff'
+              backgroundColor: 'rgba(87, 138, 205, 0.1)',
+              borderLeft: '4px solid #578acd'
             }}
           >
             <Box sx={{marginRight:'10px'}}>

--- a/src/components/sidebar/styles.ts
+++ b/src/components/sidebar/styles.ts
@@ -3,12 +3,13 @@ import styled from "styled-components";
 export const SidebarContainer = styled.div`
     display: flex;
     flex-direction: column;
-    background: linear-gradient(180deg, #001f3f, #003366); /* Degradê azul marinho */
-    color: white;
+    background: linear-gradient(180deg, #578acd, #38639a);
+    color: #fff;
     width: 220px;
     min-width: 300px;
-    height: 100vh; /* Ocupa toda a altura da tela */
+    height: 100vh;
     overflow: hidden;
+    border-radius: 12px;
     @media (max-width: 600px) {
         width: 100%;
         height: 100%;
@@ -73,7 +74,7 @@ export const SidebarContainerHeaderProfile = styled.img`
     width: 80px;
     height: 80px;
     border-radius: 50%;
-    border: 2px solid #00a8ff; /* Borda azul clara */
+    border: 2px solid #578acd;
 `;
 
 export const SidebarContainerHeaderProfileName = styled.p`
@@ -101,17 +102,17 @@ export const SidebarContainerBodyElementContainer = styled.div`
 
 export const SidebarContainerBodyElementIcon = styled.div`
     margin-right: 10px;
-    color: #00a8ff; /* Azul claro */
+    color: #fff;
 `;
 
 export const SidebarContainerBodyElement = styled.p`
     margin: 0;
     font-size: 1em;
-    color: white;
+    color: #fff;
     transition: color 0.3s ease;
     &:hover {
         cursor: pointer;
-        color: #00a8ff; /* Azul claro no hover */
+        color: #578acd;
     }
 `;
 
@@ -127,14 +128,14 @@ export const SupportModuleLabel = styled.div`
 
 export const MainModuleIndicator = styled.span`
   font-size: 0.8em;
-  color: #00a8ff;
+  color: #fff;
   margin-left: 5px;
 `;
 
 export const ActiveModuleIndicator = styled.div`
   width: 8px;
   height: 8px;
-  background-color: #00a8ff;
+  background-color: #fff;
   border-radius: 50%;
   display: inline-block;
   margin-left: 8px;

--- a/src/components/sidepanel/sidepanel.tsx
+++ b/src/components/sidepanel/sidepanel.tsx
@@ -195,13 +195,13 @@ const SidePanel = forwardRef<HTMLDivElement, SidePanelProps>(
         >
           <button
             style={{
-              backgroundColor: "#5a86b5",
-              color: "white",
+              backgroundColor: "#578acd",
+              color: "#fff",
               border: "none",
               padding: "10px 20px",
               textAlign: "center",
               fontSize: "16px",
-              borderRadius: "5px",
+              borderRadius: "8px",
               cursor: "pointer",
               width: "130px",
               marginLeft: window.innerWidth > 600 ? "-30%" : "-4%",

--- a/src/components/sidepanel/styles.ts
+++ b/src/components/sidepanel/styles.ts
@@ -27,8 +27,8 @@ export const EventContainer = styled.div<{ status: string }>`
   padding-right: 20px;
   margin: 10px 0;
   background-color: ${({ status }) => (status === "canceled" ? "#f8d7da" : "#f1f1f16b")};
-  border-left: 5px solid ${({ status }) => (status === "canceled" ? "#e74c3c" : "#5a86b5")};
-  border-radius: 4px;
+  border-left: 5px solid ${({ status }) => (status === "canceled" ? "#e74c3c" : "#578acd")};
+  border-radius: 8px;
   justify-content: space-between;
   cursor:pointer;
 `
@@ -52,7 +52,7 @@ export const EventDetails = styled.div`
 export const EventTitle = styled.h4`
   margin: 0;
   font-size: 16px;
-  color: ${({ status }) => (status === "canceled" ? "#e74c3c" : "#007bff")};
+  color: ${({ status }) => (status === "canceled" ? "#e74c3c" : "#578acd")};
 `;
 
 export const EventDescription = styled.p`
@@ -105,20 +105,20 @@ export const FormInput = styled.input`
 
   &:focus {
     outline: none; // Remove default outline
-    border-color: #5a86b5; // Change border color on focus
+    border-color: #578acd;
   }
 `;
 
 export const FormButton = styled.button`
-  background-color: #4CAF50; // Green background
-  color: white; // White text
-  border: none; // No border
-  padding: 10px; // Padding
-  border-radius: 5px; // Rounded corners
-  cursor: pointer; // Pointer cursor on hover
-  font-size: 16px; // Font size
-  transition: background-color 0.3s; // Transition effect
+  background-color: #578acd;
+  color: #fff;
+  border: none;
+  padding: 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 16px;
+  transition: background-color 0.3s;
   &:hover {
-    background-color: #45a049; // Darker green on hover
+    background-color: #38639a;
   }
 `;


### PR DESCRIPTION
## Summary
- refine marketing capture page buttons and cards with brand color
- soften automation dashboard buttons and cards
- restyle CRM metrics and actions for a lighter blue theme

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef293ade48321aed0da9f1b95dd57