### PR TITLE
Implement mobile bottom tab hide-on-scroll

### DIFF
--- a/src/components/marketing/automation/mobile/index.tsx
+++ b/src/components/marketing/automation/mobile/index.tsx
@@ -18,6 +18,7 @@ import {
   Avatar,
   Stack
 } from "@mui/material";
+import useHideOnScroll from "../../../../hooks/useHideOnScroll.ts";
 import {
   Add,
   Edit,
@@ -47,6 +48,7 @@ const AutomationDashboard = ({ activeCompany, setModule }) => {
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
   const theme = useTheme();
+  const hideNav = useHideOnScroll();
 
   const fetchAutomations = useCallback(async () => {
     if (!activeCompany) return;
@@ -410,12 +412,13 @@ const AutomationDashboard = ({ activeCompany, setModule }) => {
           position: "fixed",
           bottom: 16,
           left: "50%",
-          transform: "translateX(-50%)",
+          transform: `translateX(-50%) ${hideNav ? 'translateY(100%)' : 'translateY(0)'}`,
           width: "calc(100% - 32px)",
           maxWidth: 400,
           borderRadius: 3,
           zIndex: 1,
-          border: "1px solid rgba(0,0,0,0.05)"
+          border: "1px solid rgba(0,0,0,0.05)",
+          transition: "transform 0.3s"
         }}
       >
         <BottomNavigation

--- a/src/components/marketing/mobile/index.tsx
+++ b/src/components/marketing/mobile/index.tsx
@@ -18,6 +18,7 @@ import {
   Collapse
 } from "@mui/material";
 import { Line, Bar } from "react-chartjs-2";
+import useHideOnScroll from "../../../hooks/useHideOnScroll.ts";
 import {
   Brain,
   FileText,
@@ -62,6 +63,7 @@ const MobileMarketingDashboard: React.FC<{ activeCompany }> = ({ ...props }) => 
   const [navValue, setNavValue] = useState('home');
   const isSmallScreen = useMediaQuery(theme.breakpoints.down('sm'));
   const [glance, setGlance] = useState(null);
+  const hideNav = useHideOnScroll();
 
     useEffect(() => {
     const fetchProgress = async () => {
@@ -700,7 +702,9 @@ const cards = [
           right: 0,
           bgcolor: '#fff',
           boxShadow: '0 -2px 10px rgba(0,0,0,0.05)',
-          borderTop: '1px solid rgba(0,0,0,0.05)'
+          borderTop: '1px solid rgba(0,0,0,0.05)',
+          transform: hideNav ? 'translateY(100%)' : 'translateY(0)',
+          transition: 'transform 0.3s'
         }}
       >
         <BottomNavigationAction

--- a/src/components/sidebar/mobile/index.tsx
+++ b/src/components/sidebar/mobile/index.tsx
@@ -15,6 +15,7 @@ import CampaignIcon from '@mui/icons-material/Campaign';
 import ModulesService from '../../../services/modules.service.ts';
 import HomeService from '../../../services/home.service.ts';
 import { SidebarWrapper, TopSection, CompanyHeader, CompanyAvatar, CompanyLogo, CompanyPlaceholder, CompanyInfo, CompanyName, ChevronIcon, CompanyDropdown, CompanyOption, CompanyLogoWrapper, CompanyOptionInfo, CompanyOptionName, SelectedIndicator, GlowingDot, BottomSection, ModulesScroll, ModulesContainer, CompactModuleItem, CompactModuleIcon, CompactModuleLabel, LogoutItem, LogoutLabel } from './styles.ts';
+import useHideOnScroll from '../../../hooks/useHideOnScroll.ts';
 
 const BottomNavContainer = styled(Box)`
   display: flex;
@@ -115,6 +116,7 @@ const MobileBottomNavigation = ({
   const [expandedTop, setExpandedTop] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const colorThief = new ColorThief();
+  const hideNav = useHideOnScroll();
 
   useEffect(() => {
     if (userData._id) {
@@ -266,7 +268,13 @@ const MobileBottomNavigation = ({
         )}
       </TopSection> */}
 
-      <BottomNavContainer sx={{ top: expanded ? '120px' : 'unset' }}>
+      <BottomNavContainer
+        sx={{
+          top: expanded ? '120px' : 'unset',
+          transform: hideNav ? 'translateY(100%)' : 'translateY(0)',
+          transition: 'transform 0.3s'
+        }}
+      >
         <NavItemsWrapper>
           {mainNavItems.map(item => (
             <Tooltip key={item?.key} title={item.label} placement="top" arrow>

--- a/src/hooks/useHideOnScroll.ts
+++ b/src/hooks/useHideOnScroll.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef, useState } from 'react';
+
+export default function useHideOnScroll(threshold: number = 10) {
+  const [hidden, setHidden] = useState(false);
+  const lastY = useRef(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (window.innerWidth > 600) return;
+      const currentY = window.scrollY;
+      if (currentY > lastY.current && currentY - lastY.current > threshold) {
+        setHidden(true);
+      } else if (
+        currentY < lastY.current &&
+        lastY.current - currentY > threshold
+      ) {
+        setHidden(false);
+      }
+      lastY.current = currentY;
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [threshold]);
+
+  return hidden;
+}


### PR DESCRIPTION
## Summary
- add `useHideOnScroll` hook
- hide bottom navigation when scrolling down on mobile in Sidebar, Marketing dashboard and Automation dashboard

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500e9562c883219cd18410d310e9cc