### PR TITLE
Add CRM column selection feature

### DIFF
--- a/src/data/en.json
+++ b/src/data/en.json
@@ -655,7 +655,9 @@
       "lastContact": "Last Contact",
       "tags": "Tags",
       "source": "Source",
-      "createdAt": "Created At"
+      "createdAt": "Created At",
+      "selectColumns": "Select Columns",
+      "columns": "Columns"
     },
     "automationTable": {
       "emptyStateTitle": "No automation found",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -661,7 +661,9 @@
       "lastContact": "Último Contato",
       "tags": "Tags",
       "source": "Origem",
-      "createdAt": "Data de Criação"
+      "createdAt": "Data de Criação",
+      "selectColumns": "Selecionar Colunas",
+      "columns": "Colunas"
     },
     "automationTable": {
       "emptyStateTitle": "Nenhuma automação encontrada",


### PR DESCRIPTION
## Summary
- allow CRM table columns to be selected
- support column selection in desktop and mobile views
- include dynamic `jsonData` fields in the picker
- update translations for new options

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685091dc16948321aeac6d1b698b3a44