### PR TITLE
Fix segment filter crash when segment has no conditions

### DIFF
--- a/src/components/marketing/crm/index.tsx
+++ b/src/components/marketing/crm/index.tsx
@@ -106,11 +106,12 @@ const CRMApp: React.FC = ({ activeCompany, setModule }) => {
     let result = [...customers];
 
     // Aplica filtro de segmento
-    if (selectedSegment) {
-      const segment = segments.find(s => s.id === selectedSegment);
-      if (segment) {
-        result = result.filter(customer => {
-          return segment.filterConditions.every(condition => {
+      if (selectedSegment) {
+        const segment = segments.find(s => s.id === selectedSegment);
+        if (segment) {
+          const conditions = segment.filterConditions || [];
+          result = result.filter(customer => {
+            return conditions.every(condition => {
             const field = condition.field as string;
 
             // Busca o valor: pode estar no customer ou no jsonData

--- a/src/components/marketing/crm/mobile/index.tsx
+++ b/src/components/marketing/crm/mobile/index.tsx
@@ -164,11 +164,12 @@ const CRMAppMobile: React.FC<{ activeCompany: any, setModule: (module: string) =
   const filterCustomers = () => {
     let result = [...customers];
 
-    if (selectedSegment) {
-      const segment = segments.find(s => s.id === selectedSegment);
-      if (segment) {
-        result = result.filter(customer =>
-          segment.filterConditions.every((condition: any) => {
+      if (selectedSegment) {
+        const segment = segments.find(s => s.id === selectedSegment);
+        if (segment) {
+          const conditions = segment.filterConditions || [];
+          result = result.filter(customer =>
+            conditions.every((condition: any) => {
             const field = condition.field as string;
             const customerValue =
               (customer as any)[field] !== undefined


### PR DESCRIPTION
## Summary
- handle missing `filterConditions` when filtering CRM customers
- handle missing `filterConditions` on mobile CRM filtering

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685096c884cc832198a452e80a521bfe