### PR TITLE
Improve CRM table with card view

### DIFF
--- a/src/components/Customers/index.tsx
+++ b/src/components/Customers/index.tsx
@@ -383,6 +383,7 @@ const Customers: React.FC<CustomersProps> = ({ activeCompany }) => {
       >
         {tableData && tableData.length > 0 ? (
           <DefaultTable
+            asCards
             data={tableData}
             columns={columns}
             handleRow={(rowData: any) => {

--- a/src/components/employees/index.tsx
+++ b/src/components/employees/index.tsx
@@ -243,7 +243,7 @@ const Employees: React.FC<{ activeCompany }> = ({ ...props }) => {
           renderEmptyState(setIsOpen)
         ) : (
             <div style={{maxWidth: window.innerWidth < 600 ? '100%' : 'unset', overflowX: window.innerWidth < 600 ? 'scroll' : 'unset'}}>
-                <DefaultTable columns={columns} data={tableData} handleRow={handleRow} />
+                <DefaultTable asCards columns={columns} data={tableData} handleRow={handleRow} />
             </div>
         )}
       </div>

--- a/src/components/products/index.tsx
+++ b/src/components/products/index.tsx
@@ -288,7 +288,7 @@ const Products: React.FC<{ activeCompany }> = ({ ...props }) => {
                 renderEmptyState()
             ) : (
                 <div style={{maxWidth: window.innerWidth < 600 ? '90%' : 'unset', overflowX: window.innerWidth < 600 ? 'scroll' : 'unset'}}>
-                    <DefaultTable columns={columns} data={tableData} handleRow={handleRow} />
+                    <DefaultTable asCards columns={columns} data={tableData} handleRow={handleRow} />
                 </div>
             )}
 

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -1,5 +1,14 @@
 import React from 'react';
-import { TableCustomer, TrCustomer, ThCustomer, TdCustomer } from './styles.ts';
+import {
+  TableCustomer,
+  TrCustomer,
+  ThCustomer,
+  TdCustomer,
+  CardContainer,
+  DataCard,
+  CardField,
+  CardLabel,
+} from './styles.ts';
 
 interface Column {
   header: string;
@@ -9,10 +18,32 @@ interface Column {
 interface DefaultTableProps {
   columns: Column[];
   data: any[];
-  handleRow?: any;
+  handleRow?: (row: any) => void;
+  asCards?: boolean;
 }
 
-const DefaultTable: React.FC<DefaultTableProps> = ({ columns, data, handleRow }) => {
+const DefaultTable: React.FC<DefaultTableProps> = ({ columns, data, handleRow, asCards }) => {
+  if (asCards) {
+    return (
+      <CardContainer>
+        {data && data.length > 0 ? (
+          data.map((row, rowIndex) => (
+            <DataCard key={rowIndex} onClick={() => handleRow && handleRow(row)}>
+              {columns.map((col, colIndex) => (
+                <CardField key={colIndex}>
+                  <CardLabel>{col.header}:</CardLabel>
+                  {row[col.accessor]}
+                </CardField>
+              ))}
+            </DataCard>
+          ))
+        ) : (
+          <p>No data available</p>
+        )}
+      </CardContainer>
+    );
+  }
+
   return (
     <TableCustomer>
       <thead>

--- a/src/components/table/styles.ts
+++ b/src/components/table/styles.ts
@@ -39,3 +39,30 @@ export const TableWrapperCustomer = styled.div`
   height: 100px;
   margin-top: 2%;
 `;
+
+export const CardContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 16px 0;
+`;
+
+export const DataCard = styled.div`
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 16px;
+  min-width: 260px;
+  cursor: pointer;
+  flex: 1;
+`;
+
+export const CardField = styled.div`
+  margin-bottom: 8px;
+  word-wrap: break-word;
+`;
+
+export const CardLabel = styled.span`
+  font-weight: 600;
+  margin-right: 6px;
+`;


### PR DESCRIPTION
## Summary
- modernize the default table by adding an optional card layout
- add styles for card view
- display CRM data as cards on products, customers and employees pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850992ffa7c8321bbcc77b60f4e8acf