### PR TITLE
Enable dynamic CRM fields

### DIFF
--- a/src/data/en.json
+++ b/src/data/en.json
@@ -657,7 +657,10 @@
       "source": "Source",
       "createdAt": "Created At",
       "selectColumns": "Select Columns",
-      "columns": "Columns"
+      "columns": "Columns",
+      "addField": "Add Field",
+      "fieldName": "Field Name",
+      "fieldValue": "Field Value"
     },
     "automationTable": {
       "emptyStateTitle": "No automation found",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -663,7 +663,10 @@
       "source": "Origem",
       "createdAt": "Data de Criação",
       "selectColumns": "Selecionar Colunas",
-      "columns": "Colunas"
+      "columns": "Colunas",
+      "addField": "Adicionar Campo",
+      "fieldName": "Nome do Campo",
+      "fieldValue": "Valor do Campo"
     },
     "automationTable": {
       "emptyStateTitle": "Nenhuma automação encontrada",


### PR DESCRIPTION
## Summary
- allow custom fields for CRM leads
- sync column logic on mobile CRM with desktop
- add pt/en translations for custom field feature

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509e61258c83219c05fc87dee3b1f2