### PR TITLE
Fix CRM segment filter

### DIFF
--- a/src/components/marketing/crm/index.tsx
+++ b/src/components/marketing/crm/index.tsx
@@ -107,7 +107,7 @@ const CRMApp: React.FC = ({ activeCompany, setModule }) => {
 
     // Aplica filtro de segmento
       if (selectedSegment) {
-        const segment = segments.find(s => s.id === selectedSegment);
+        const segment = segments.find(s => String(s.id) === selectedSegment);
         if (segment) {
           const conditions = segment.filterConditions || [];
           result = result.filter(customer => {
@@ -168,8 +168,8 @@ const CRMApp: React.FC = ({ activeCompany, setModule }) => {
     setSearchText(e.target.value);
   };
 
-  const handleSegmentChange = (segmentId: string) => {
-    setSelectedSegment(segmentId);
+  const handleSegmentChange = (segmentId: string | number | null) => {
+    setSelectedSegment(segmentId !== null && segmentId !== undefined ? String(segmentId) : null);
   };
 
   const handleCreateSegment = () => {

--- a/src/components/marketing/crm/mobile/index.tsx
+++ b/src/components/marketing/crm/mobile/index.tsx
@@ -187,7 +187,7 @@ const CRMAppMobile: React.FC<{ activeCompany: any, setModule: (module: string) =
     let result = [...customers];
 
       if (selectedSegment) {
-        const segment = segments.find(s => s.id === selectedSegment);
+        const segment = segments.find(s => String(s.id) === selectedSegment);
         if (segment) {
           const conditions = segment.filterConditions || [];
           result = result.filter(customer =>
@@ -267,8 +267,8 @@ const CRMAppMobile: React.FC<{ activeCompany: any, setModule: (module: string) =
     setSearchText(e.target.value);
   };
 
-  const handleSegmentChange = (segmentId: string) => {
-    setSelectedSegment(segmentId);
+  const handleSegmentChange = (segmentId: string | number | null) => {
+    setSelectedSegment(segmentId !== null && segmentId !== undefined ? String(segmentId) : null);
   };
 
   const handleCreateSegment = () => {

--- a/src/modules/modules.tsx
+++ b/src/modules/modules.tsx
@@ -51,4 +51,4 @@ export const dashboardModules = [
   },
 ];
 
-export default dashboardModules
+export default dashboardModules;


### PR DESCRIPTION
## Summary
- ensure segmentation lookup uses string ids
- handle numeric values for segment selection on desktop and mobile
- clean newline endings

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a72885b083219248e1e3c93be44e