### PR TITLE
Add funnel creation and selection

### DIFF
--- a/src/data/en.json
+++ b/src/data/en.json
@@ -710,7 +710,11 @@
       "cancel": "Cancel",
       "noLeads": "No leads in this stage",
       "settings": "Kanban Settings",
-      "reorderStages": "Reorder Stages"
+      "reorderStages": "Reorder Stages",
+      "selectFunnel": "Select Funnel",
+      "addFunnel": "Add Funnel",
+      "newFunnel": "New Funnel",
+      "funnelName": "Funnel Name"
     },
     "automationTable": {
       "emptyStateTitle": "No automation found",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -716,7 +716,11 @@
       "cancel": "Cancelar",
       "noLeads": "Nenhum lead nesta etapa",
       "settings": "Configurações do Kanban",
-      "reorderStages": "Reordenar Etapas"
+      "reorderStages": "Reordenar Etapas",
+      "selectFunnel": "Selecionar Funil",
+      "addFunnel": "Adicionar Funil",
+      "newFunnel": "Novo Funil",
+      "funnelName": "Nome do Funil"
     },
     "automationTable": {
       "emptyStateTitle": "Nenhuma automação encontrada",


### PR DESCRIPTION
## Summary
- allow selecting funnels and creating new funnels
- add translations for funnel creation

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851993a656c8321834389e77789846a