### PR TITLE
Add create funnel modal

### DIFF
--- a/src/data/en.json
+++ b/src/data/en.json
@@ -726,7 +726,11 @@
       "selectFunnel": "Select Funnel",
       "addFunnel": "Add Funnel",
       "newFunnel": "New Funnel",
-      "funnelName": "Funnel Name"
+      "funnelName": "Funnel Name",
+      "createFunnel": "Create Funnel",
+      "funnelDescription": "Funnel Description",
+      "segmentation": "Segmentation",
+      "selectSegmentation": "Select a segmentation"
     },
     "automationTable": {
       "emptyStateTitle": "No automation found",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -732,7 +732,11 @@
       "selectFunnel": "Selecionar Funil",
       "addFunnel": "Adicionar Funil",
       "newFunnel": "Novo Funil",
-      "funnelName": "Nome do Funil"
+      "funnelName": "Nome do Funil",
+      "createFunnel": "Criar Fúnil",
+      "funnelDescription": "Descrição do Funil",
+      "segmentation": "Segmentação",
+      "selectSegmentation": "Selecione uma segmentação"
     },
     "automationTable": {
       "emptyStateTitle": "Nenhuma automação encontrada",


### PR DESCRIPTION
## Summary
- add translation entries for creating sales funnels
- implement modal to create a funnel in sales funnel board

## Testing
- `npm install` *(fails: ERESOLVE dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_6851c05f96b4832187cf5e2027143066