### PR TITLE
Update sales funnel translations

### DIFF
--- a/src/components/marketing/funnel/index.tsx
+++ b/src/components/marketing/funnel/index.tsx
@@ -531,7 +531,7 @@ const KanbanColumnComponent = ({ column, onAddCard, onEditStage, onDeleteStage, 
               ))
             ) : (
               <EmptyState onClick={onAddCard}>
-                <Plus size={18} /> {t('kanban.addFirstCard')}
+                <Plus size={18} /> {t('salesFunnel.addFirstLead')}
               </EmptyState>
             )}
             {provided.placeholder}
@@ -791,7 +791,7 @@ const SalesFunnel: React.FC<{ activeCompany?: string }> = ({ activeCompany }) =>
     <DragDropContext onDragEnd={onDragEnd}>
       <KanbanContainer>
         <KanbanHeader>
-          <h1>{t('kanban.title')}</h1>
+          <h1>{t('salesFunnel.title')}</h1>
           <Controls>
             <SearchBox>
               <Search size={18} color="#94a3b8" />
@@ -893,7 +893,7 @@ const SalesFunnel: React.FC<{ activeCompany?: string }> = ({ activeCompany }) =>
               setFunnelSegment('');
             } catch (err) {
               console.error('Erro ao criar funil', err);
-              enqueueSnackbar('Erro ao criar funil', { variant: 'error' });
+              enqueueSnackbar(t('salesFunnel.errorCreatingFunnel'), { variant: 'error' });
             }
           }}>{t('salesFunnel.save')}</Button>
         </DialogActions>

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -733,7 +733,9 @@
       "selectSegmentation": "Select a segmentation",
       "stageName": "Stage Name",
       "confirmDeleteStageTitle": "Confirm deletion",
-      "confirmDeleteStageMessage": "Are you sure you want to delete this stage?"
+      "confirmDeleteStageMessage": "Are you sure you want to delete this stage?",
+      "addFirstLead": "Add first lead",
+      "errorCreatingFunnel": "Error creating funnel. Please try again."
     },
     "automationTable": {
       "emptyStateTitle": "No automation found",
@@ -1123,7 +1125,7 @@
     }
   },
   "kanban": {
-    "title": "Project Board",
+    "title": "Sales Funnel",
     "todo": "To Do",
     "inProgress": "In Progress",
     "review": "Review",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -739,7 +739,9 @@
       "selectSegmentation": "Selecione uma segmentação",
       "stageName": "Nome da Etapa",
       "confirmDeleteStageTitle": "Confirmar exclusão",
-      "confirmDeleteStageMessage": "Tem certeza que deseja excluir esta etapa?"
+      "confirmDeleteStageMessage": "Tem certeza que deseja excluir esta etapa?",
+      "addFirstLead": "Adicionar o primeiro lead",
+      "errorCreatingFunnel": "Erro ao criar funil. Por favor tente novamente."
     },
     "automationTable": {
       "emptyStateTitle": "Nenhuma automação encontrada",
@@ -1130,7 +1132,7 @@
     }
   },
   "kanban": {
-    "title": "Quadro de Projetos",
+    "title": "Fúnil de Vendas",
     "todo": "A Fazer",
     "inProgress": "Em Progresso",
     "review": "Revisão",


### PR DESCRIPTION
## Summary
- localize Sales Funnel strings
- add missing keys for English and Portuguese

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_6852bb0037a08321977a62895f18b76a