### PR TITLE
Show lead details modal in sales funnel

### DIFF
--- a/src/components/marketing/funnel/index.tsx
+++ b/src/components/marketing/funnel/index.tsx
@@ -26,6 +26,7 @@ import CrmService from '../../../services/crm.service.ts';
 import SegmentationService from '../../../services/segmentation.service.ts';
 import FunnelService from '../../../services/funnel.service.ts';
 import { ArrowBackIos } from '@mui/icons-material';
+import LeadDetailsModal from './lead-details-modal';
 
 // ======================
 // Estilos com Styled Components
@@ -435,7 +436,7 @@ interface Segment {
 // Componentes React
 // ======================
 
-const KanbanCardComponent = ({ card, index }) => {
+const KanbanCardComponent = ({ card, index, onClick }) => {
   return (
     <Draggable draggableId={card.id} index={index}>
       {(provided, snapshot) => (
@@ -444,6 +445,7 @@ const KanbanCardComponent = ({ card, index }) => {
           {...provided.draggableProps}
           {...provided.dragHandleProps}
           isDragging={snapshot.isDragging}
+          onClick={onClick}
         >
           <PriorityTag className={card.priority}>{card.priority}</PriorityTag>
           <CardHeader>
@@ -489,7 +491,7 @@ const KanbanCardComponent = ({ card, index }) => {
   );
 };
 
-const KanbanColumnComponent = ({ column, onAddCard, onEditStage, onDeleteStage, innerRef, dragHandleProps, draggableProps }) => {
+const KanbanColumnComponent = ({ column, onAddCard, onEditStage, onDeleteStage, onViewLead, innerRef, dragHandleProps, draggableProps }) => {
   const { t } = useTranslation();
   const [showMenu, setShowMenu] = useState(false);
 
@@ -528,7 +530,12 @@ const KanbanColumnComponent = ({ column, onAddCard, onEditStage, onDeleteStage, 
           <CardsContainer>
             {column.cards.length > 0 ? (
               column.cards.map((card, index) => (
-                <KanbanCardComponent key={card.id} card={card} index={index} />
+                <KanbanCardComponent
+                  key={card.id}
+                  card={card}
+                  index={index}
+                  onClick={() => onViewLead(card.id)}
+                />
               ))
             ) : (
               <EmptyState onClick={onAddCard}>
@@ -565,6 +572,7 @@ const SalesFunnel: React.FC<{ activeCompany?: string, setModule:any }> = ({ acti
   const [editingStage, setEditingStage] = useState<string | null>(null);
   const [deleteStage, setDeleteStage] = useState<string | null>(null);
   const [leadActivities, setLeadActivities] = useState<Record<string, string>>({});
+  const [viewLead, setViewLead] = useState<Lead | null>(null);
 
   useEffect(() => {
     if (!activeCompany) return;
@@ -851,6 +859,11 @@ const updateColumns = () => {
     setDeleteStage(null);
   };
 
+  const handleViewLead = (id: string) => {
+    const lead = leads.find(l => l.id === id);
+    if (lead) setViewLead(lead);
+  };
+
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <KanbanContainer>
@@ -898,6 +911,7 @@ const updateColumns = () => {
                   onAddCard={() => handleAddCard(column.id)}
                   onEditStage={(stage) => handleEditStage(stage)}
                   onDeleteStage={(stage) => handleDeleteStage(stage)}
+                  onViewLead={handleViewLead}
                 />
               ))}
               {provided.placeholder}
@@ -993,6 +1007,11 @@ const updateColumns = () => {
           <Button color="error" variant="contained" onClick={confirmDeleteStage}>{t('salesFunnel.delete')}</Button>
         </DialogActions>
       </Dialog>
+      <LeadDetailsModal
+        open={!!viewLead}
+        lead={viewLead}
+        onClose={() => setViewLead(null)}
+      />
     </DragDropContext>
   );
 

--- a/src/components/marketing/funnel/lead-details-modal.tsx
+++ b/src/components/marketing/funnel/lead-details-modal.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Table,
+  TableBody,
+  TableRow,
+  TableCell,
+  Button
+} from '@mui/material';
+
+interface Lead {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  status: string;
+  lastContact: Date;
+  value: number;
+  source: string;
+  jsonData: Record<string, any>;
+}
+
+interface LeadDetailsModalProps {
+  open: boolean;
+  lead: Lead | null;
+  onClose: () => void;
+}
+
+const LeadDetailsModal: React.FC<LeadDetailsModalProps> = ({ open, lead, onClose }) => {
+  if (!lead) return null;
+
+  const details: Record<string, any> = {
+    name: lead.name,
+    email: lead.email,
+    phone: lead.phone,
+    status: lead.status,
+    lastContact: lead.lastContact ? new Date(lead.lastContact).toLocaleDateString() : '',
+    value: lead.value,
+    source: lead.source,
+    ...lead.jsonData
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Lead Details</DialogTitle>
+      <DialogContent dividers>
+        <Table>
+          <TableBody>
+            {Object.entries(details).map(([key, value]) => (
+              <TableRow key={key}>
+                <TableCell>{key}</TableCell>
+                <TableCell>{String(value)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default LeadDetailsModal;

--- a/src/components/marketing/funnel/mobile/index.tsx
+++ b/src/components/marketing/funnel/mobile/index.tsx
@@ -26,6 +26,7 @@ import SegmentationService from '../../../../services/segmentation.service.ts';
 import FunnelService from '../../../../services/funnel.service.ts';
 import { ArrowBackIos } from '@mui/icons-material';
 import { PlusOutlined } from '@ant-design/icons';
+import LeadDetailsModal from '../lead-details-modal';
 
 // ======================
 // Estilos com Styled Components para Mobile
@@ -396,12 +397,12 @@ interface Segment {
 // Componentes React para Mobile
 // ======================
 
-const KanbanCardMobile = ({ card, onMove }) => {
+const KanbanCardMobile = ({ card, onMove, onClick }) => {
   const { t } = useTranslation();
   const [showMenu, setShowMenu] = useState(false);
 
   return (
-    <KanbanCardMobileContainer>
+    <KanbanCardMobileContainer onClick={onClick}>
       <PriorityTagMobile className={card.priority}>{card.priority}</PriorityTagMobile>
       <CardHeaderMobile>
         <h4>{card.title}</h4>
@@ -454,7 +455,8 @@ const StageAccordionComponent = ({
   onEditStage,
   onDeleteStage,
   onAddCard,
-  onMoveLead
+  onMoveLead,
+  onViewLead
 }) => {
   const { t } = useTranslation();
   const [showMenu, setShowMenu] = useState(false);
@@ -496,7 +498,12 @@ const StageAccordionComponent = ({
         <CardsContainerMobile>
         {column.cards.length > 0 ? (
         column.cards.map((card) => (
-            <KanbanCardMobile key={card.id} card={card} onMove={() => onMoveLead(card.id)} />
+            <KanbanCardMobile
+              key={card.id}
+              card={card}
+              onMove={() => onMoveLead(card.id)}
+              onClick={() => onViewLead(card.id)}
+            />
         ))
         ) : (
         <EmptyStateMobile onClick={onAddCard}>
@@ -534,6 +541,7 @@ const SalesFunnelMobile: React.FC<{ activeCompany?: string, setModule: any }> = 
   const [moveLeadModalOpen, setMoveLeadModalOpen] = useState(false);
   const [selectedLeadId, setSelectedLeadId] = useState<string>('');
   const [selectedStageId, setSelectedStageId] = useState<string>('');
+  const [viewLead, setViewLead] = useState<Lead | null>(null);
 
   useEffect(() => {
     if (!activeCompany) return;
@@ -723,6 +731,11 @@ const SalesFunnelMobile: React.FC<{ activeCompany?: string, setModule: any }> = 
   const handleMoveLead = (leadId: string) => {
     setSelectedLeadId(leadId);
     setMoveLeadModalOpen(true);
+  };
+
+  const handleViewLead = (leadId: string) => {
+    const lead = leads.find(l => l.id === leadId);
+    if (lead) setViewLead(lead);
   };
 
   const confirmMoveLead = async () => {
@@ -928,6 +941,7 @@ const SalesFunnelMobile: React.FC<{ activeCompany?: string, setModule: any }> = 
             onDeleteStage={handleDeleteStage}
             onAddCard={() => {}}
             onMoveLead={handleMoveLead}
+            onViewLead={handleViewLead}
           />
         ))}
 
@@ -1056,6 +1070,11 @@ const SalesFunnelMobile: React.FC<{ activeCompany?: string, setModule: any }> = 
           </Button>
         </DialogActions>
       </Dialog>
+      <LeadDetailsModal
+        open={!!viewLead}
+        lead={viewLead}
+        onClose={() => setViewLead(null)}
+      />
     </MobileContainer>
   );
 };


### PR DESCRIPTION
## Summary
- add `LeadDetailsModal` component
- display full lead details when clicking cards on desktop
- show same modal on mobile funnel board

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530f3fa9a48321888d0949ae402684