### PR TITLE
Add Sales Pages module

### DIFF
--- a/src/components/marketing/index.tsx
+++ b/src/components/marketing/index.tsx
@@ -40,6 +40,7 @@ import { useTranslation } from "react-i18next";
 import LeadGeneration from "./create-leads/index.tsx";
 import React from "react";
 import CapturePages from "./capture-pages/index.tsx";
+import SalesPages from "./sales-pages/index.tsx";
 import AutomationDashboard from "./automation/index.tsx";
 import SocialMediaDashboard from "./social-media/index.tsx";
 import StyledAIAssistant from "./ai/index.tsx";
@@ -255,7 +256,8 @@ const MarketingDashboard: React.FC<{ activeCompany }> = ({ ...props }) => {
     createLeads: ['marketingAi'],
     automation: ['marketingAi', 'createLeads'],
     crm: ['marketingAi', 'createLeads', 'automation'],
-    funnel: ['marketingAi', 'createLeads', 'automation', 'crm']
+    funnel: ['marketingAi', 'createLeads', 'automation', 'crm'],
+    salesPage: ['marketingAi', 'createLeads', 'automation', 'crm']
   };
 
   const isModuleUnlocked = (moduleKey) => {
@@ -421,10 +423,9 @@ const cards = [
     title: t("marketing.sales_page"),
     description: t("marketing.sales_page_desc"),
     module: "salesPage",
-    color: theme.palette.text.disabled,
+    color: theme.palette.primary.main,
     completed: isModuleCompleted("salesPage"),
-    disabled: true,
-    comingSoon: true
+    disabled: false
   },
 ];
 
@@ -440,7 +441,8 @@ const cards = [
     { id: 'createLeads', label: 'Landing Page', icon: <Layout size={16} /> },
     { id: 'automation', label: 'Automation', icon: <Zap size={16} /> },
     { id: 'crm', label: 'CRM', icon: <Users size={16} /> },
-    { id: 'funnel', label: 'Funnel', icon: <FileText size={16} /> }
+    { id: 'funnel', label: 'Funnel', icon: <FileText size={16} /> },
+    { id: 'salesPage', label: 'Sales Page', icon: <Coins size={16} /> }
   ];
 
   return (
@@ -878,6 +880,8 @@ const cards = [
             setModule={setModule}
             onComplete={() => handleModuleComplete('crm')}
           />
+        ) : module === 'salesPage' ? (
+          <SalesPages activeCompany={props.activeCompany} setModule={setModule} onComplete={() => handleModuleComplete('salesPage')} />
         ) : module === 'funnel' ? (
           <SalesFunnel activeCompany={props.activeCompany} setModule={setModule} />
         ) : module === 'chatbot' ? (

--- a/src/components/marketing/mobile/index.tsx
+++ b/src/components/marketing/mobile/index.tsx
@@ -51,6 +51,7 @@ import SalesFunnel from "../funnel/index.tsx";
 import UserProgressService from '../../../services/user-progress.service.ts'
 import { RobotOutlined } from "@ant-design/icons";
 import MobileCapturePages from "../capture-pages/mobile/index.tsx";
+import MobileSalesPages from "../sales-pages/mobile/index.tsx";
 import PremiumMarketingAssistantMobile from "../ai/mobile/index.tsx";
 import MarketingService from "../../../services/marketing.service.ts";
 import {ChatbotManager} from "../chatbot/index.tsx";
@@ -106,7 +107,8 @@ const moduleDependencies = {
   createLeads: ['marketingAi'],
   automation: ['marketingAi', 'createLeads'],
   crm: ['marketingAi', 'createLeads' ,'automation'],
-  funnel: ['marketingAi', 'createLeads', 'automation', 'crm']
+  funnel: ['marketingAi', 'createLeads', 'automation', 'crm'],
+  salesPage: ['marketingAi', 'createLeads', 'automation', 'crm']
 };
 
 const isModuleCompleted = (moduleKey) => {
@@ -252,7 +254,8 @@ const PulseDot = styled(Box)(({ theme }) => ({
       { id: 'createLeads', label: 'Landing Page', icon: <Layout size={16} /> },
       { id: 'automation', label: 'Automação', icon: <Zap size={16} /> },
       { id: 'crm', label: 'CRM', icon: <Users size={16} /> },
-      { id: 'funnel', label: 'Vendas', icon: <FileText size={16} /> }
+      { id: 'funnel', label: 'Vendas', icon: <FileText size={16} /> },
+      { id: 'salesPage', label: 'Sales Page', icon: <Coins size={16} /> }
     ];
 
   useEffect(() => {
@@ -433,10 +436,9 @@ const cards = [
     title: t("marketing.sales_page"),
     description: t("marketing.sales_page_desc"),
     module: "salesPage",
-    color: theme.palette.text.disabled,
+    color: theme.palette.primary.main,
     completed: isModuleCompleted("salesPage"),
-    disabled: true,
-    comingSoon: true
+    disabled: false
   },
 ];
 
@@ -458,6 +460,8 @@ const cards = [
     return <SalesFunnelMobile activeCompany={props.activeCompany} setModule={setModule} />;
   }else if (module === 'chatbot') {
     return <ChatbotManager activeCompany={props.activeCompany} setModule={setModule} />;
+  } else if (module === 'salesPage') {
+    return <MobileSalesPages activeCompany={props.activeCompany} setModule={setModule} onComplete={() => handleModuleComplete('salesPage')} />;
   }
 
   return (

--- a/src/components/marketing/sales-pages/index.tsx
+++ b/src/components/marketing/sales-pages/index.tsx
@@ -1,0 +1,1392 @@
+import { useState, useEffect } from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Button,
+  Grid,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Skeleton,
+  Box,
+  Tabs,
+  Tab,
+  ToggleButtonGroup,
+  ToggleButton,
+  FormGroup,
+  FormControlLabel,
+  Checkbox,
+  CircularProgress,
+  LinearProgress,
+} from "@mui/material";
+import { AlertCircle, Check, CheckCircle, Clock, ExternalLink, Eye, Pencil, PlusCircle } from "lucide-react";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import SalesPageService from "../../../services/sales-page.service.ts";
+import LeadsService from "../../../services/leads.service.ts";
+import { useSnackbar } from "notistack";
+import ProgressService from "../../../services/progress.service.ts";
+
+// Importações para o Chart.js
+import { Bar } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import LeadGeneration from "../create-leads/index.tsx";
+import FormDetailsModal from "../leads-details/index.tsx";
+import { AccessTime, ArrowBackIos, Close, FormatListBulletedOutlined, InsertDriveFileOutlined } from "@mui/icons-material";
+import AiService from "../../../services/ai.service.ts";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+// -----------------------
+// Interfaces
+// -----------------------
+
+interface Template {
+  componentScreenshotUrl: any;
+  id: string;
+  type: string;
+  name: string;
+  description: string;
+  screenshotUrl: string;
+}
+
+interface PageView {
+  timestamp: string;
+  isNewUser: boolean;
+}
+
+interface SalesPage {
+  id: string;
+  title: string;
+  description: string;
+  views: number;
+  createdAt: string;
+  screenshotUrl?: string;
+  pageviews?: PageView[];
+  isActive?: boolean;
+}
+
+interface FormSubmission {
+  id: string;
+  apiKey: string;
+  pageUrl: string;
+  referrer: string;
+  timestamp: string;
+  location?: {
+    latitude: number;
+    longitude: number;
+    accuracy: number;
+  };
+  device?: any;
+  gender?: any;
+  age?: any;
+  language?: string;
+  createdAt?: string;
+  isNewUser?: boolean;
+  fingerprint?: string;
+}
+
+interface FormDetail {
+  id: string;
+  formId: string;
+  responseData: { [key: string]: any };
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FormLead {
+  id: string;
+  title: string;
+  description: string;
+  message: string;
+  templateId: string;
+  companyId: string;
+  apiKey: string;
+  incentives: {
+    ebook: boolean;
+    webinar: boolean;
+    desconto: boolean;
+    consultoria: boolean;
+  };
+  incentiveDetails: {
+    ebook?: string;
+    webinar?: string;
+    desconto?: string;
+    consultoria?: string;
+    others?: string;
+  };
+  extraActions: {
+    whatsappButton: boolean;
+    subscribeNewsletter: boolean;
+    followSocials: boolean;
+    requestCallback: boolean;
+  };
+  salesOptions: {
+    sellBefore: boolean;
+    sellAfter: boolean;
+    discountOffer: boolean;
+    noOffer?: boolean;
+  };
+  fields: { name: string; type: string }[];
+  created_at?: Date;
+  updated_at?: Date;
+  html: string;
+  formlead: FormSubmission[];
+}
+
+interface IFormData {
+  title: string;
+  description: string;
+  companyId: string;
+  message: string;
+  templateId: string;
+  incentives: {
+    ebook: boolean;
+    webinar: boolean;
+    desconto: boolean;
+    consultoria: boolean;
+    others: boolean;
+  };
+  incentiveDetails: {
+    ebook?: string;
+    webinar?: string;
+    desconto?: string;
+    consultoria?: string;
+    others?: string;
+  };
+  extraActions: {
+    whatsappButton: boolean;
+    subscribeNewsletter: boolean;
+    followSocials: boolean;
+    requestCallback: boolean;
+  };
+  salesOptions: {
+    sellBefore: boolean;
+    sellAfter: boolean;
+    noOffer: boolean;
+  };
+  fields: { name: string; type: string }[];
+}
+
+// -----------------------
+// Função Auxiliar
+// -----------------------
+
+function ensureAbsolute(url: string): string {
+  if (!url || url.trim() === "") return "#";
+  if (url.startsWith("http://") || url.startsWith("https://")) return url;
+  return "http://" + url;
+}
+
+// -----------------------
+// Componentes de Gráficos
+// -----------------------
+
+const PageViewChart: React.FC<{ pageviews: PageView[] }> = ({ pageviews }) => {
+  const { t } = useTranslation();
+  const getLast7Days = () => {
+    const days = [];
+    for (let i = 6; i >= 0; i--) {
+      const date = new Date();
+      date.setDate(date.getDate() - i);
+      const formattedDate = `${String(date.getDate()).padStart(2, "0")}/${String(
+        date.getMonth() + 1
+      ).padStart(2, "0")}/${date.getFullYear()}`;
+      days.push(formattedDate);
+    }
+    return days;
+  };
+
+  const days = getLast7Days();
+
+  const pageViewCounts = days.map((day) =>
+    pageviews.filter(
+      (pv) => new Date(pv.timestamp).toLocaleDateString("pt-BR") === day
+    ).length
+  );
+
+  const newUserCounts = days.map((day) =>
+    pageviews.filter(
+      (pv) =>
+        new Date(pv.timestamp).toLocaleDateString("pt-BR") === day && pv.isNewUser
+    ).length
+  );
+
+  const data = {
+    labels: days,
+    datasets: [
+      {
+        label: t("charts.pageViews"),
+        data: pageViewCounts,
+        backgroundColor: "rgba(75, 192, 192, 0.6)",
+      },
+      {
+        label: t("charts.newUsers"),
+        data: newUserCounts,
+        backgroundColor: "rgba(153, 102, 255, 0.6)",
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { position: "top" as const },
+      title: { display: true },
+    },
+  };
+
+  return (
+    <div style={{ height: "300px" }}>
+      <Bar data={data} options={options} />
+    </div>
+  );
+};
+
+const FormSubmissionsChart: React.FC<{ submissions: FormSubmission[] }> = ({ submissions }) => {
+  const { t } = useTranslation();
+  const getLast7Days = () => {
+    const days = [];
+    for (let i = 6; i >= 0; i--) {
+      const date = new Date();
+      date.setDate(date.getDate() - i);
+      const formattedDate = `${String(date.getDate()).padStart(2, "0")}/${String(
+        date.getMonth() + 1
+      ).padStart(2, "0")}/${date.getFullYear()}`;
+      days.push(formattedDate);
+    }
+    return days;
+  };
+
+  const days = getLast7Days();
+
+  const totalCounts = days.map((day) =>
+    submissions.filter(
+      (s) => new Date(s.timestamp).toLocaleDateString("pt-BR") === day
+    ).length
+  );
+
+  const newUserCounts = days.map((day) =>
+    submissions.filter(
+      (s) =>
+        new Date(s.timestamp).toLocaleDateString("pt-BR") === day && s.isNewUser
+    ).length
+  );
+
+  const data = {
+    labels: days,
+    datasets: [
+      {
+        label: t("charts.views"),
+        data: totalCounts,
+        backgroundColor: "rgba(255, 159, 64, 0.6)",
+      },
+      {
+        label: t("charts.newUsersForForms"),
+        data: newUserCounts,
+        backgroundColor: "rgba(54, 162, 235, 0.6)",
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { position: "top" as const },
+      title: { display: false },
+    },
+  };
+
+  return (
+    <div style={{ height: "150px", marginTop: "10px" }}>
+      <Bar data={data} options={options} />
+    </div>
+  );
+};
+
+// -----------------------
+// Componentes de Cards
+// -----------------------
+
+const SalesPageCard: React.FC<{
+  page: SalesPage;
+  onViewDetails: (page: SalesPage) => void;
+  onViewWebsite: (page: SalesPage) => void;
+  onEdit: (page: SalesPage) => void;
+}> = ({ page, onViewDetails, onViewWebsite, onEdit }) => {
+  const { t } = useTranslation();
+  return (
+    <Grid item xs={12} sm={6} md={4} key={page.id}>
+      <Card>
+        {page.screenshotUrl ? (
+          <img
+            src={page.screenshotUrl}
+            alt={page.title}
+            style={{ width: "100%", height: 180, objectFit: "cover" }}
+          />
+        ) : page.pageviews && page.pageviews.length > 0 ? (
+          <div style={{ padding: "10px", marginTop: "-30px" }}>
+            <PageViewChart pageviews={page.pageviews} />
+          </div>
+        ) : (
+          <Skeleton variant="rectangular" width="100%" height={290} />
+        )}
+        <CardContent>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <Typography variant="h6" component="span">
+              {page.title} -
+            </Typography>
+            <Box
+              sx={{
+                width: 12,
+                height: 12,
+                borderRadius: "50%",
+                backgroundColor: page.isActive
+                  ? "rgba(0, 255, 0, 0.7)"
+                  : "rgba(255, 0, 0, 0.7)",
+                marginLeft: "10px",
+                boxShadow: page.isActive
+                  ? "0 0 3px rgba(0, 255, 0, 0.9)"
+                  : "0 0 3px rgba(255, 0, 0, 0.9)",
+                cursor: "pointer",
+              }}
+            />
+          </div>
+          <Typography variant="body2" color="textSecondary">
+            {page.description}
+          </Typography>
+          <Typography variant="caption" color="textSecondary" display="block" style={{ marginTop: 8 }}>
+            {t("marketing.capturePages.views", { count: page.views })}
+          </Typography>
+          <Typography variant="caption" color="textSecondary" display="block">
+            {t("marketing.capturePages.createdAt")}: {new Date(page.createdAt).toLocaleDateString()}
+          </Typography>
+        </CardContent>
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-start",
+        alignItems: "flex-start",
+        margin: "8px"
+      }}
+    >
+      <Button
+        size="small"
+        onClick={() => onViewDetails(page)}
+        startIcon={<Eye size={16} color="#578acd" />}
+      >
+        {t("marketing.capturePages.viewDetails")}
+      </Button>
+
+      <Button
+        size="small"
+        onClick={() => onEdit(page)}
+        startIcon={<Pencil size={16} color="#578acd" />}
+        sx={{ marginLeft: '0px' }}
+      >
+        {t("marketing.capturePages.editPage")} Sales Page
+      </Button>
+
+      <Button
+        size="small"
+        onClick={() => onViewWebsite(page)}
+        startIcon={<ExternalLink size={16} color="#578acd" />}
+      >
+        {t("marketing.capturePages.viewSalesPage")}
+      </Button>
+    </Box>
+      </Card>
+    </Grid>
+  );
+};
+
+const FormCard: React.FC<{
+  form: FormLead;
+  onViewDetails: (form: FormLead) => void;
+  onViewWebsite: (form: FormLead) => void;
+}> = ({ form, onViewDetails, onViewWebsite }) => {
+  const { t } = useTranslation();
+  return (
+    <Grid item xs={12} sm={6} md={4} key={form.id}>
+      <Card>
+        <CardContent>
+          <Typography variant="h6">{form.title}</Typography>
+          <Typography variant="body2" color="textSecondary">
+            {form.description || t("marketing.capturePages.noDescription")}
+          </Typography>
+          <Typography variant="caption" color="textSecondary" display="block">
+            {t("marketing.capturePages.createdAt")}: {new Date(form.created_at || form.updated_at || Date.now()).toLocaleDateString()}
+          </Typography>
+          <FormSubmissionsChart submissions={form.formlead} />
+        </CardContent>
+        <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "flex-start", alignItems: "flex-start", margin: "8px" }}>
+          <Button size="small" onClick={() => onViewDetails(form)}>
+            {t("marketing.capturePages.viewDetails")}
+          </Button>
+          <Button size="small" onClick={() => onViewWebsite(form)}>
+            {t("marketing.capturePages.viewForm")}
+          </Button>
+        </Box>
+      </Card>
+    </Grid>
+  );
+};
+
+// -----------------------
+// Diálogo para Seleção de Template
+// -----------------------
+
+const TemplateDialog: React.FC<{
+  open: boolean;
+  onClose: () => void;
+  templates: Template[];
+  loading: boolean;
+  selectedTemplate: Template | null;
+  setSelectedTemplate: (template: Template) => void;
+  newPage: { title: string; description: string; aiPrompt?: string };
+  setNewPage: React.Dispatch<React.SetStateAction<{ title: string; description: string; aiPrompt?: string }>>;
+  activeCompany: any;
+  setPreviewUrl: (url: string) => void;
+}> = ({
+  open,
+  onClose,
+  templates,
+  loading,
+  selectedTemplate,
+  setSelectedTemplate,
+  newPage,
+  setNewPage,
+  activeCompany,
+  setPreviewUrl,
+}) => {
+  const { t } = useTranslation();
+  const [mode, setMode] = useState<"choose" | "ai">("choose");
+  const [sections, setSections] = useState<string[]>([
+    "navbar", "benefits", "social proof", "prices", "call to action", "footer",
+  ]);
+  const [customSectionInput, setCustomSectionInput] = useState("");
+  const [progress, setProgress] = useState();
+  const [generating, setGenerating] = useState(false);
+
+  const sectionLabels: Record<string, string> = {
+    navbar: t("marketing.templateSections.navbar"),
+    benefits: t("marketing.templateSections.benefits"),
+    demo: t("marketing.templateSections.demo"),
+    "social proof": t("marketing.templateSections.social proof"),
+    prices: t("marketing.templateSections.prices"),
+    "call to action": t("marketing.templateSections.call to action"),
+    footer: t("marketing.templateSections.footer"),
+  };
+
+  const handleDrag = (e: React.DragEvent<HTMLDivElement>, index: number) => {
+    e.dataTransfer.setData("sectionIndex", index.toString());
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, dropIndex: number) => {
+    const draggedIndex = parseInt(e.dataTransfer.getData("sectionIndex"));
+    if (!isNaN(draggedIndex)) {
+      const updated = [...sections];
+      const [removed] = updated.splice(draggedIndex, 1);
+      updated.splice(dropIndex, 0, removed);
+      setSections(updated);
+    }
+  };
+
+  const handleAddCustomSection = () => {
+    const trimmed = customSectionInput.trim();
+    if (trimmed && !sections.includes(trimmed)) {
+      const withoutFooter = sections.filter((s) => s !== "footer");
+      setSections([...withoutFooter, trimmed, "footer"]);
+      setCustomSectionInput("");
+    }
+  };
+
+  useEffect(() => {
+    if (!generating) return;
+
+    const interval = setInterval(() => {
+      ProgressService.getProgress(activeCompany)
+        .then((res) => {
+          setProgress(res.data);
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [generating]);
+
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+      <DialogContent>
+      {generating ? (
+        <Box
+          mt={4}
+          p={4}
+          borderRadius="12px"
+          bgcolor="rgba(255, 255, 255, 0.9)"
+          boxShadow="0 8px 32px rgba(0, 0, 0, 0.05)"
+          border="1px solid rgba(0, 0, 0, 0.05)"
+          sx={{
+            backdropFilter: 'blur(8px)',
+            background: 'linear-gradient(135deg, rgba(255,255,255,0.96) 0%, rgba(248,250,252,0.96) 100%)'
+          }}
+        >
+          <Typography
+            variant="h6"
+            gutterBottom
+            sx={{
+              fontWeight: 600,
+              color: 'text.primary',
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1
+            }}
+          >
+            <CircularProgress
+              size={24}
+              thickness={4}
+              sx={{
+                color: 'primary.main',
+                animationDuration: '800ms'
+              }}
+            />
+            Generating your template...
+          </Typography>
+
+          <Box
+            component="ul"
+            sx={{
+              pl: 0,
+              mt: 2,
+              mb: 0,
+              display: 'grid',
+              gap: 1.5
+            }}
+          >
+            {sections.map((section) => {
+              const status = progress?.[section];
+              const label = sectionLabels?.[section] || section;
+
+              return (
+                <Box
+                  key={section}
+                  component="li"
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 2,
+                    p: 1.5,
+                    borderRadius: '8px',
+                    transition: 'all 0.3s ease',
+                    backgroundColor: status === 'loading' ? 'rgba(0, 100, 255, 0.03)' : 'transparent',
+                    '&:hover': {
+                      backgroundColor: 'rgba(0, 0, 0, 0.02)'
+                    }
+                  }}
+                >
+                  <Box sx={{ position: 'relative', width: 24, height: 24 }}>
+                    {status === 'loading' ? (
+                      <CircularProgress
+                        size={24}
+                        thickness={4}
+                        sx={{
+                          color: 'primary.main',
+                          position: 'absolute',
+                          animationDuration: '800ms'
+                        }}
+                      />
+                    ) : status === 'done' ? (
+                      <Box
+                        sx={{
+                          width: 24,
+                          height: 24,
+                          borderRadius: '50%',
+                          backgroundColor: 'success.light',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center'
+                        }}
+                      >
+                        <Check
+                          sx={{
+                            color: 'success.contrastText',
+                            fontSize: 16
+                          }}
+                        />
+                      </Box>
+                    ) : status === 'error' ? (
+                      <Box
+                        sx={{
+                          width: 24,
+                          height: 24,
+                          borderRadius: '50%',
+                          backgroundColor: 'error.light',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center'
+                        }}
+                      >
+                        <Close
+                          sx={{
+                            color: 'error.contrastText',
+                            fontSize: 16
+                          }}
+                        />
+                      </Box>
+                    ) : (
+                      <Box
+                        sx={{
+                          width: 24,
+                          height: 24,
+                          borderRadius: '50%',
+                          backgroundColor: 'action.disabledBackground',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center'
+                        }}
+                      >
+                        <AccessTime
+                          sx={{
+                            color: 'action.disabled',
+                            fontSize: 16
+                          }}
+                        />
+                      </Box>
+                    )}
+                  </Box>
+
+                  <Typography
+                    variant="body1"
+                    sx={{
+                      fontWeight: 500,
+                      color: status === 'error' ? 'error.main' : 'text.primary',
+                      flexGrow: 1
+                    }}
+                  >
+                    {label}
+                  </Typography>
+
+                  {status === 'loading' && (
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        color: 'text.secondary',
+                        fontFeatureSettings: '"tnum"'
+                      }}
+                    >
+                      Processing...
+                    </Typography>
+                  )}
+                </Box>
+              );
+            })}
+          </Box>
+
+          <Box
+            sx={{
+              mt: 3,
+              pt: 2,
+              borderTop: '1px solid',
+              borderColor: 'divider',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center'
+            }}
+          >
+            <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+              {sections.filter(s => progress?.[s] === 'done' || progress?.[s] === 'error').length} of {sections.length} completed
+            </Typography>
+
+            <LinearProgress
+              variant="determinate"
+              value={(sections.filter(s => progress?.[s] === 'done' || progress?.[s] === 'error').length / sections.length) * 100}
+              sx={{
+                height: 6,
+                borderRadius: 3,
+                width: '60%',
+                backgroundColor: 'action.selected',
+                '& .MuiLinearProgress-bar': {
+                  borderRadius: 3,
+                  backgroundColor: 'primary.main'
+                }
+              }}
+            />
+          </Box>
+        </Box>
+      ) : (
+          <>
+            <ToggleButtonGroup
+              value={mode}
+              exclusive
+              onChange={(_, newMode) => newMode && setMode(newMode)}
+              sx={{ mb: 2 }}
+              fullWidth
+            >
+              <ToggleButton value="choose">{t("marketing.templateDialog.chooseTemplate")}</ToggleButton>
+              <ToggleButton value="ai">{t("marketing.templateDialog.createAiTemplate")}</ToggleButton>
+            </ToggleButtonGroup>
+
+            <TextField
+              label={t("marketing.templateDialog.titleLabel")}
+              fullWidth
+              margin="dense"
+              onChange={(e) => setNewPage({ ...newPage, title: e.target.value })}
+            />
+            <TextField
+              label={t("marketing.templateDialog.descriptionLabel")}
+              fullWidth
+              margin="dense"
+              onChange={(e) => setNewPage({ ...newPage, description: e.target.value })}
+            />
+
+            {mode === "choose" && (
+              <Grid container spacing={2} sx={{ mt: 2, p: 2, background: 'rgba(223, 223, 223, 0.187)', borderRadius: '20px' }}>
+                {loading
+                  ? [...Array(6)].map((_, index) => (
+                      <Grid item xs={4} key={index}>
+                        <Skeleton variant="rectangular" width="100%" height={180} />
+                        <Skeleton width="60%" height={25} sx={{ mt: 1 }} />
+                        <Skeleton width="80%" height={20} />
+                      </Grid>
+                    ))
+                  : templates.map((template) => (
+                      <Grid item xs={4} key={template.id}>
+                        <Card
+                          onClick={() => setSelectedTemplate(template)}
+                          sx={{
+                            cursor: "pointer",
+                            boxShadow: 3,
+                            border: selectedTemplate?.id === template.id ? "2px solid blue" : "none",
+                          }}
+                        >
+                          {template.screenshotUrl ? (
+                            <img src={template.screenshotUrl} alt={template.name} width="100%" style={{ borderRadius: 5 }} />
+                          ) : (
+                            <Skeleton variant="rectangular" width="100%" height={150} />
+                          )}
+                        </Card>
+                      </Grid>
+                    ))}
+              </Grid>
+            )}
+
+            {mode === "ai" && (
+              <Box mt={3}>
+                <TextField
+                  fullWidth
+                  multiline
+                  rows={4}
+                  placeholder={t("marketing.templateDialog.aiPromptHint")}
+                  onChange={(e) => setNewPage({ ...newPage, aiPrompt: e.target.value })}
+                />
+
+                <FormGroup sx={{ mt: 3 }}>
+                  <Typography fontWeight={600} mb={1}>{t("marketing.templateDialog.chooseSections")}</Typography>
+                  <Box>
+                    {sections.map((section, index) => (
+                      <Box
+                        key={section + index}
+                        draggable
+                        onDragStart={(e) => handleDrag(e, index)}
+                        onDragOver={(e) => e.preventDefault()}
+                        onDrop={(e) => handleDrop(e, index)}
+                        sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, p: 1, border: '1px dashed #ccc', borderRadius: 1 }}
+                      >
+                        <Checkbox
+                          checked
+                          onChange={() => {
+                            const updated = sections.filter((s) => s !== section);
+                            setSections(updated);
+                          }}
+                        />
+                        <Typography>{sectionLabels[section] || section}</Typography>
+                        <Typography variant="caption" sx={{ ml: 'auto', color: '#888', cursor:'pointer' }}>::  ::</Typography>
+                      </Box>
+                    ))}
+                  </Box>
+                </FormGroup>
+
+                <Box mt={3}>
+                  <Typography fontWeight={500} mb={1}>{t("marketing.templateDialog.addMoreSections")}</Typography>
+                  <Box display="flex" gap={1} alignItems="center">
+                    <TextField
+                      fullWidth
+                      value={customSectionInput}
+                      onChange={(e) => setCustomSectionInput(e.target.value)}
+                      placeholder="Ex: FAQ, Newsletter..."
+                      margin="dense"
+                    />
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      sx={{ height: '55px', borderTopLeftRadius:'0px', borderBottomLeftRadius:'0px', whiteSpace: 'nowrap', mt: '4px', marginLeft:'-8px' }}
+                      onClick={handleAddCustomSection}
+                    >
+                      <PlusCircle size={30}/>
+                    </Button>
+                  </Box>
+                </Box>
+              </Box>
+            )}
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t("common.cancel")}</Button>
+        <Button
+          variant="contained"
+          color="primary"
+          disabled={newPage.title === "" || (mode === "choose" && !selectedTemplate) || generating}
+          onClick={async () => {
+            if (mode === "choose") {
+              setPreviewUrl(`https://roktune.duckdns.org/sales-pages/preview?type=${selectedTemplate.type}&companyId=${activeCompany}&title=${newPage.title}`);
+            } else {
+              const orderedSections = sections.filter((s) => s.trim() !== "");
+              setGenerating(true);
+
+              await SalesPageService.postAiTemplate({
+                title: newPage.title,
+                description: newPage.description,
+                aiPrompt: newPage.aiPrompt,
+                sections: orderedSections,
+                companyId: activeCompany,
+              }).then((res)=>{
+                setGenerating(false);
+                setProgress({});
+                setPreviewUrl(`https://roktune.duckdns.org/sales-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${newPage.title}`);
+              })
+              .catch((err)=>{console.log(err)});
+
+              setGenerating(false);
+            }
+          }}
+        >
+          {mode === "choose"
+            ? t("marketing.templateDialog.viewAndEdit")
+            : t("marketing.templateDialog.generateAiTemplate")}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+// -----------------------
+// Diálogo de Pré-visualização e Edição
+// -----------------------
+
+const PreviewDialog: React.FC<{
+  open: boolean;
+  previewUrl: string | null;
+  onClose: () => void;
+  showSavingOverlay: boolean;
+  showComponents: boolean;
+  loadingComponents: boolean;
+  components: Template[];
+  handleShowComponents: () => void;
+  saveSalesPageAsActive: () => void;
+  creatingSalesPage: boolean;
+}> = ({
+  open,
+  previewUrl,
+  onClose,
+  showSavingOverlay,
+  showComponents,
+  loadingComponents,
+  components,
+  handleShowComponents,
+  saveSalesPageAsActive,
+  creatingSalesPage
+}) => {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogContent>
+        {previewUrl ? (
+          <Grid style={{ width:'100%'}}>
+            <Grid style={{ width:'100%'}} item xs={12} sm={6}>
+              <div style={{ width:'100%'}}>
+                <iframe
+                  id="previewIframe"
+                  src={previewUrl}
+                  width="100%"
+                  height="500px"
+                  style={{ border: "none" }}
+                  title={t("marketing.previewDialog.title")}
+                />
+              </div>
+            </Grid>
+          </Grid>
+        ) : (
+          <Typography variant="body2">{t("common.loading")}</Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+      <Button
+        onClick={saveSalesPageAsActive}
+        disabled={creatingSalesPage}
+        variant="contained"
+        startIcon={creatingSalesPage ? <CircularProgress size={20} /> : null}
+      >
+        {creatingSalesPage ? '' : t("marketing.previewDialog.createSalesPage")}
+      </Button>
+    </DialogActions>
+    </Dialog>
+  );
+};
+
+// -----------------------
+// Diálogo para Visualizar Detalhes da Sales Page
+// -----------------------
+
+const DetailsDialog: React.FC<{
+  open: boolean;
+  salesPage: SalesPage | null;
+  onClose: () => void;
+}> = ({ open, salesPage, onClose }) => {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>{t("marketing.detailsDialog.title")}</DialogTitle>
+      <DialogContent>
+        <Typography variant="h6">{salesPage?.title}</Typography>
+        <Typography variant="body2">{salesPage?.description}</Typography>
+        {salesPage?.pageviews && salesPage.pageviews.length > 0 ? (
+          <PageViewChart pageviews={salesPage.pageviews} />
+        ) : (
+          <Typography variant="body2">{t("marketing.detailsDialog.noPageviews")}</Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t("common.close")}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const EditDialog: React.FC<{
+  open: boolean;
+  salesPage: SalesPage | null;
+  onClose: () => void;
+  onDelete: (id: string) => void;
+}> = ({ open, salesPage, onClose, onDelete }) => {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullWidth>
+      <DialogTitle>{salesPage?.title}</DialogTitle>
+      <DialogContent>
+        {salesPage ? (
+          <iframe
+            src={`https://roktune.duckdns.org/sales-pages/edit/${salesPage.id}`}
+            width="100%"
+            height="500px"
+            style={{ border: "none" }}
+            title={salesPage.title}
+          />
+        ) : (
+          <Typography variant="body2">{t("common.loading")}</Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {salesPage && (
+          <Button color="error" onClick={() => onDelete(salesPage.id)}>
+            {t("marketing.capturePages.deletePage")}
+          </Button>
+        )}
+        <Button onClick={onClose}>{t("common.close")}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+// -----------------------
+// Componente Principal
+// -----------------------
+
+const CapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ activeCompany, setModule }) => {
+  const { t } = useTranslation();
+  const { enqueueSnackbar } = useSnackbar();
+
+  // Estado da tab: 0 = Sales Pages, 1 = Formulários
+  const [currentTab, setCurrentTab] = useState(0);
+  const [salesPages, setSalesPages] = useState<SalesPage[]>([]);
+  const [loadingPages, setLoadingPages] = useState(true);
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loadingTemplates, setLoadingTemplates] = useState(true);
+  const [openForm, setOpenForm] = useState(false);
+  const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
+  const [newPage, setNewPage] = useState({ title: "", description: "" });
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [showSavingOverlay, setShowSavingOverlay] = useState(false);
+  const [leadGenerationEnabled, setLeadGenerationEnabled] = useState(false);
+  const [viewFormDetails, setViewFormDetails] = useState("");
+  const [forms, setForms] = useState<FormLead[]>([]);
+  const [loadingForms, setLoadingForms] = useState(true);
+  const [creatingSalesPage, setCreatingSalesPage] = useState(false);
+  const [saveButton, setSaveButton] = useState(false);
+  const [selectedSalesPage, setSelectedSalesPage] = useState<SalesPage | null>(null);
+  const [editingPage, setEditingPage] = useState<SalesPage | null>(null);
+
+  const fetchSalesPages = () => {
+    if (activeCompany) {
+      setLoadingPages(true);
+      SalesPageService.getSalesPages(activeCompany)
+        .then((response) => {
+          setSalesPages(response.data);
+          setLoadingPages(false);
+        })
+        .catch((error) => {
+          console.error("Erro ao buscar landing pages:", error);
+          setLoadingPages(false);
+        });
+    }
+  };
+
+  const fetchTemplates = () => {
+    setLoadingTemplates(true);
+    SalesPageService.get()
+      .then((response) => {
+        setTemplates(response.data);
+        setLoadingTemplates(false);
+      })
+      .catch((error) => {
+        console.error("Erro ao buscar templates:", error);
+        setLoadingTemplates(false);
+      });
+  };
+
+  const fetchForms = () => {
+    if (activeCompany) {
+      setLoadingForms(true);
+      LeadsService.getForms(activeCompany)
+        .then((response) => {
+          setForms(response.data);
+          setLoadingForms(false);
+        })
+        .catch((error) => {
+          console.error("Erro ao buscar formulários:", error);
+          setLoadingForms(false);
+        });
+    }
+  };
+
+  useEffect(() => {
+    fetchTemplates();
+    fetchSalesPages();
+  }, [activeCompany]);
+
+  // Novo useEffect para buscar os templates sempre que o modal de criação for aberto
+  useEffect(() => {
+    if (openForm) {
+      fetchTemplates();
+    }
+  }, [openForm]);
+
+  useEffect(() => {
+    if (currentTab === 1) {
+      fetchForms();
+    }
+  }, [currentTab, activeCompany]);
+
+  const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
+    setCurrentTab(newValue);
+  };
+
+  const handleViewDetails = (page: SalesPage) => {
+    setSelectedSalesPage(page);
+  };
+
+  const handleViewWebsite = (page: SalesPage) => {
+    window.open(`https://roktune.duckdns.org/sales-pages/page/${page.id}`, "_blank");
+  };
+
+  const handleEditPage = (page: SalesPage) => {
+    setEditingPage(page);
+  };
+
+  const handleDeletePage = async (id: string) => {
+    try {
+      await SalesPageService.delete(id);
+      setSalesPages((prev) => prev.filter((p) => p.id !== id));
+      enqueueSnackbar(t("marketing.capturePages.pageDeleted"), { variant: "success" });
+    } catch (error) {
+      console.error("Erro ao deletar landing page:", error);
+      enqueueSnackbar(t("marketing.capturePages.deleteError"), { variant: "error" });
+    } finally {
+      setEditingPage(null);
+    }
+  };
+
+  const handleViewFormDetails = (form: FormLead) => {
+    // Aqui, para o modal de detalhes dos formulários, definimos o formId para que o modal faça o fetch
+    setViewFormDetails(form.id);
+  };
+
+  const handleViewFormWebsite = (form: FormLead) => {
+    window.open(`https://roktune.duckdns.org/leads/form?apiKey=${form.apiKey}`, "_blank");
+  };
+
+  const saveSalesPageAsActive = async () => {
+    if(!saveButton){
+      enqueueSnackbar('Click on save button before creating a new landing page', {variant:'info'})
+      setSaveButton(true)
+    }
+    const iframe = document.getElementById("previewIframe") as HTMLIFrameElement;
+    console.log(iframe.contentDocument)
+    if (iframe?.contentWindow && iframe.contentDocument) {
+      const saveButton = iframe.contentDocument.getElementById("saveButton") as HTMLButtonElement;
+      if (saveButton) {
+        saveButton.click();
+      } else {
+        console.error("Botão saveButton não encontrado dentro do iframe.");
+      }
+    } else {
+      console.error("Iframe não encontrado ou inacessível.");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 10000));
+
+    SalesPageService.post({ companyId: activeCompany, title: newPage.title })
+      .then((res) => {
+        enqueueSnackbar(t("marketing.capturePages.pageCreated"), {
+          variant: "success",
+        });
+        setPreviewUrl(null);
+        setOpenForm(false);
+        fetchSalesPages();
+      })
+      .catch((error) => {
+        console.error("Erro ao criar landing page:", error);
+      }).finally(()=>{
+        setCreatingSalesPage(false)
+      });
+  };
+
+
+  if (leadGenerationEnabled) {
+    return <LeadGeneration activeCompany={activeCompany} setModule={setModule} />;
+  }
+
+  return (
+    <div style={{ padding: "20px" }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Box sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+        gap: 2,
+        marginBottom: 2
+      }}>
+          <Box sx={{display:'flex'}}>
+            <ArrowBackIos style={{cursor:'pointer', marginTop:'10px', marginRight:'20px'}} onClick={()=>{setModule('')}}/>
+            <Typography variant="h4">
+              {t("marketing.capturePages.title")}
+            </Typography>
+          </Box>
+
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Button
+            variant="contained"
+            color="primary"
+            startIcon={<PlusCircle />}
+            onClick={() => setOpenForm(true)}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            {t("marketing.capturePages.createSalesPage")}
+          </Button>
+
+          <Button
+            variant="contained"
+            color="primary"
+            startIcon={<PlusCircle />}
+            onClick={() => setLeadGenerationEnabled(true)}
+            sx={{ whiteSpace: 'nowrap' }}
+          >
+            {t("marketing.capturePages.createForm")}
+          </Button>
+        </Box>
+      </Box>
+
+      <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+        <Tabs value={currentTab} onChange={handleTabChange}>
+          <Tab label={t("marketing.capturePages.salesPagesTab")} />
+          <Tab label={t("marketing.capturePages.formsTab")} />
+        </Tabs>
+      </Box>
+    </Box>
+
+      {currentTab === 0 && (
+        <Box sx={{ marginTop: "20px" }}>
+          <Grid container spacing={2}>
+            {loadingPages ? (
+              Array.from(new Array(3)).map((_, index) => (
+                <Grid item xs={12} sm={6} md={4} key={index}>
+                  <Skeleton variant="rectangular" width="100%" height={180} />
+                  <Skeleton width="80%" height={20} style={{ marginTop: 10 }} />
+                  <Skeleton width="60%" height={20} />
+                </Grid>
+              ))
+            ) : salesPages.length > 0 ? (
+              salesPages.map((page) => (
+                <SalesPageCard
+                  key={page.id}
+                  page={page}
+                  onViewDetails={handleViewDetails}
+                  onViewWebsite={handleViewWebsite}
+                  onEdit={handleEditPage}
+                />
+              ))
+            ) : (
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "100%",
+              mt: 8,
+              opacity: 0.8,
+            }}
+          >
+            <InsertDriveFileOutlined sx={{ fontSize: 80, color: "grey.400" }} />
+            <Typography variant="h6" sx={{ mt: 2 }}>
+              {t("marketing.capturePages.noSalesPageFound")}
+            </Typography>
+            <Typography variant="body2" sx={{ mt: 1, color: "text.secondary" }}>
+              {t("marketing.capturePages.tryCreatingOne")}
+            </Typography>
+            <Button
+              variant="outlined"
+              color="primary"
+              sx={{ mt: 3 }}
+              onClick={setOpenForm}
+            >
+              {t("marketing.capturePages.createPage")}
+            </Button>
+          </Box>
+            )}
+          </Grid>
+        </Box>
+      )}
+
+      {currentTab === 1 && (
+        <Box sx={{ marginTop: "20px" }}>
+          {loadingForms ? (
+            <Grid container spacing={2}>
+              {Array.from(new Array(6)).map((_, i) => (
+                <Grid item xs={4} key={i}>
+                  <Skeleton variant="rectangular" width="100%" height={150} />
+                  <Skeleton width="60%" height={25} style={{ marginTop: "10px" }} />
+                  <Skeleton width="80%" height={20} />
+                </Grid>
+              ))}
+            </Grid>
+          ) : forms.length > 0 ? (
+            <Grid container spacing={2}>
+              {forms.map((form) => (
+                <FormCard
+                  key={form.id}
+                  form={form}
+                  onViewDetails={handleViewFormDetails}
+                  onViewWebsite={handleViewFormWebsite}
+                />
+              ))}
+            </Grid>
+          ) : (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            mt: 8,
+            opacity: 0.8,
+          }}
+        >
+          <FormatListBulletedOutlined sx={{ fontSize: 80, color: "grey.400" }} />
+          <Typography variant="h6" sx={{ mt: 2 }}>
+            {t("marketing.capturePages.noFormFound")}
+          </Typography>
+          <Typography variant="body2" sx={{ mt: 1, color: "text.secondary" }}>
+            {t("marketing.capturePages.tryCreatingOneForm")}
+          </Typography>
+          <Button
+            variant="outlined"
+            color="primary"
+            sx={{ mt: 3 }}
+            onClick={setLeadGenerationEnabled}
+          >
+            {t("marketing.capturePages.createForm")}
+          </Button>
+        </Box>
+          )}
+        </Box>
+      )}
+
+      <TemplateDialog
+        open={openForm}
+        onClose={() => setOpenForm(false)}
+        templates={templates}
+        loading={loadingTemplates}
+        selectedTemplate={selectedTemplate}
+        setSelectedTemplate={setSelectedTemplate}
+        newPage={newPage}
+        setNewPage={setNewPage}
+        activeCompany={activeCompany}
+        setPreviewUrl={setPreviewUrl}
+      />
+
+      <PreviewDialog
+        open={Boolean(previewUrl)}
+        previewUrl={previewUrl}
+        onClose={() => setPreviewUrl(null)}
+        showSavingOverlay={showSavingOverlay}
+        showComponents={false}
+        loadingComponents={false}
+        components={[]}
+        handleShowComponents={() => {}}
+        saveSalesPageAsActive={saveSalesPageAsActive}
+        creatingSalesPage={creatingSalesPage}
+      />
+
+      <DetailsDialog
+        open={Boolean(selectedSalesPage)}
+        salesPage={selectedSalesPage}
+        onClose={() => setSelectedSalesPage(null)}
+      />
+
+      <EditDialog
+        open={Boolean(editingPage)}
+        salesPage={editingPage}
+        onClose={() => setEditingPage(null)}
+        onDelete={handleDeletePage}
+      />
+
+      <FormDetailsModal
+        open={viewFormDetails !== ""}
+        formId={viewFormDetails}
+        onClose={() => setViewFormDetails("")}
+      />
+    </div>
+  );
+};
+
+export default CapturePages;

--- a/src/components/marketing/sales-pages/mobile/index.tsx
+++ b/src/components/marketing/sales-pages/mobile/index.tsx
@@ -1,0 +1,1327 @@
+import { useState, useEffect } from "react";
+import {
+  Card,
+  CardContent,
+  Typography,
+  Button,
+  Grid,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Skeleton,
+  Box,
+  Tabs,
+  Tab,
+  ToggleButtonGroup,
+  ToggleButton,
+  FormGroup,
+  FormControlLabel,
+  Checkbox,
+  CircularProgress,
+  LinearProgress,
+  IconButton,
+  Chip,
+  Avatar,
+  useMediaQuery,
+  useTheme,
+  alpha
+} from "@mui/material";
+import { AlertCircle, Check, CheckCircle, Clock, PlusCircle, ArrowLeft } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useSnackbar } from "notistack";
+import { AccessTime, ArrowBackIos, Close, FormatListBulletedOutlined, InsertDriveFileOutlined } from "@mui/icons-material";
+import { Bar } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import LeadGeneration from "../../create-leads/index.tsx";
+import SalesPageService from "../../../../services/sales-page.service.ts";
+import LeadsService from "../../../../services/leads.service.ts";
+import ProgressService from "../../../../services/progress.service.ts";
+import { PlusOutlined } from "@ant-design/icons";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+// Interfaces (mantidas as mesmas do original)
+interface Template {
+  componentScreenshotUrl: any;
+  id: string;
+  type: string;
+  name: string;
+  description: string;
+  screenshotUrl: string;
+}
+
+interface PageView {
+  timestamp: string;
+  isNewUser: boolean;
+}
+
+interface SalesPage {
+  id: string;
+  title: string;
+  description: string;
+  views: number;
+  createdAt: string;
+  screenshotUrl?: string;
+  pageviews?: PageView[];
+  isActive?: boolean;
+}
+
+interface FormSubmission {
+  id: string;
+  apiKey: string;
+  pageUrl: string;
+  referrer: string;
+  timestamp: string;
+  location?: {
+    latitude: number;
+    longitude: number;
+    accuracy: number;
+  };
+  device?: any;
+  gender?: any;
+  age?: any;
+  language?: string;
+  createdAt?: string;
+  isNewUser?: boolean;
+  fingerprint?: string;
+}
+
+interface FormDetail {
+  id: string;
+  formId: string;
+  responseData: { [key: string]: any };
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FormLead {
+  id: string;
+  title: string;
+  description: string;
+  message: string;
+  templateId: string;
+  companyId: string;
+  apiKey: string;
+  incentives: {
+    ebook: boolean;
+    webinar: boolean;
+    desconto: boolean;
+    consultoria: boolean;
+  };
+  incentiveDetails: {
+    ebook?: string;
+    webinar?: string;
+    desconto?: string;
+    consultoria?: string;
+    others?: string;
+  };
+  extraActions: {
+    whatsappButton: boolean;
+    subscribeNewsletter: boolean;
+    followSocials: boolean;
+    requestCallback: boolean;
+  };
+  salesOptions: {
+    sellBefore: boolean;
+    sellAfter: boolean;
+    discountOffer: boolean;
+    noOffer?: boolean;
+  };
+  fields: { name: string; type: string }[];
+  created_at?: Date;
+  updated_at?: Date;
+  html: string;
+  formlead: FormSubmission[];
+}
+
+
+const FormSubmissionsChart: React.FC<{ submissions: FormSubmission[] }> = ({ submissions }) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  const getLast7Days = () => {
+    const days = [];
+    for (let i = 6; i >= 0; i--) {
+      const date = new Date();
+      date.setDate(date.getDate() - i);
+      days.push(date.toLocaleDateString("pt-BR", { day: "2-digit", month: "short" }));
+    }
+    return days;
+  };
+
+  const days = getLast7Days();
+  const totalCounts = days.map(day =>
+    submissions.filter(s =>
+      new Date(s.timestamp).toLocaleDateString("pt-BR", { day: "2-digit", month: "short" }) === day
+    ).length
+  );
+
+  const newUserCounts = days.map(day =>
+    submissions.filter(s =>
+      new Date(s.timestamp).toLocaleDateString("pt-BR", { day: "2-digit", month: "short" }) === day && s.isNewUser
+    ).length
+  );
+
+  const data = {
+    labels: days,
+    datasets: [
+      {
+        label: t("charts.views"),
+        data: totalCounts,
+        backgroundColor: alpha(theme.palette.warning.main, 0.6),
+        borderRadius: 4
+      },
+      {
+        label: t("charts.newUsersForForms"),
+        data: newUserCounts,
+        backgroundColor: alpha(theme.palette.info.main, 0.6),
+        borderRadius: 4
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        display: false
+      },
+    },
+    scales: {
+      x: {
+        grid: { display: false },
+        ticks: { font: { size: 9 } }
+      },
+      y: {
+        grid: { color: alpha(theme.palette.divider, 0.5) },
+        ticks: { font: { size: 9 } }
+      }
+    }
+  };
+
+  return <Bar data={data} options={options} />;
+};
+
+const EditDialog: React.FC<{
+  open: boolean;
+  landingPage: SalesPage | null;
+  onClose: () => void;
+  onDelete: (id: string) => void;
+}> = ({ open, landingPage, onClose, onDelete }) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="lg" fullScreen={isMobile} fullWidth>
+      <DialogTitle>{landingPage?.title}</DialogTitle>
+      <DialogContent>
+        {landingPage ? (
+          <iframe
+            src={`https://roktune.duckdns.org/sales-pages/edit/${landingPage.id}`}
+            width="100%"
+            height={isMobile ? '100%' : '500px'}
+            style={{ border: 'none' }}
+            title={landingPage.title}
+          />
+        ) : (
+          <Typography variant="body2">{t('common.loading')}</Typography>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {landingPage && (
+          <Button color="error" onClick={() => onDelete(landingPage.id)}>
+            {t('marketing.capturePages.deletePage')}
+          </Button>
+        )}
+        <Button onClick={onClose}>{t('common.close')}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+// Componente Principal
+const MobileCapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ activeCompany, setModule }) => {
+  const { t } = useTranslation();
+  const { enqueueSnackbar } = useSnackbar();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  // Estado
+  const [currentTab, setCurrentTab] = useState(0);
+  const [salesPages, setSalesPages] = useState<SalesPage[]>([]);
+  const [loadingPages, setLoadingPages] = useState(true);
+  const [forms, setForms] = useState<FormLead[]>([]);
+  const [loadingForms, setLoadingForms] = useState(true);
+  const [openForm, setOpenForm] = useState(false);
+  const [selectedSalesPage, setSelectedSalesPage] = useState<SalesPage | null>(null);
+  const [viewFormDetails, setViewFormDetails] = useState("");
+  const [leadGenerationEnabled, setLeadGenerationEnabled] = useState(false);
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loadingTemplates, setLoadingTemplates] = useState(true);
+  const [selectedTemplate, setSelectedTemplate] = useState<Template | null>(null);
+  const [newPage, setNewPage] = useState({ title: "", description: "" });
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [creatingSalesPage, setCreatingSalesPage] = useState(false);
+  const [editingPage, setEditingPage] = useState<SalesPage | null>(null);
+  const [useAI, setUseAI] = useState(false);
+  const [generatingAI, setGeneratingAI] = useState(false);
+  const [progress, setProgress] = useState<{ [key: string]: 'loading' | 'done' | 'error' }>({});
+  const [aiPrompt, setAiPrompt] = useState("");
+  const [generating, setGenerating] = useState(false);
+  const [customSectionInput, setCustomSectionInput] = useState("");
+  const sectionLabels: Record<string, string> = {
+  navbar: t("marketing.templateSections.navbar"),
+  benefits: t("marketing.templateSections.benefits"),
+  demo: t("marketing.templateSections.demo"),
+  "social proof": t("marketing.templateSections.social proof"),
+  prices: t("marketing.templateSections.prices"),
+  "call to action": t("marketing.templateSections.call to action"),
+  footer: t("marketing.templateSections.footer"),
+};
+  const [sections, setSections] = useState<string[]>([
+    "navbar", "benefits", "social proof", "prices", "call to action", "footer",
+  ]);
+
+    useEffect(() => {
+    if (openForm) {
+      setLoadingTemplates(true);
+      SalesPageService.get()
+        .then((res) => setTemplates(res.data))
+        .catch(() => enqueueSnackbar("Erro ao buscar templates", { variant: "error" }))
+        .finally(() => setLoadingTemplates(false));
+    }
+  }, [openForm]);
+
+  useEffect(() => {
+    if (activeCompany) {
+      setLoadingPages(true);
+      SalesPageService.getSalesPages(activeCompany)
+        .then((res) => setSalesPages(res.data))
+        .catch((err) => enqueueSnackbar("Erro ao carregar landing pages", { variant: "error" }))
+        .finally(() => setLoadingPages(false));
+
+      if (currentTab === 1) {
+        setLoadingForms(true);
+        LeadsService.getForms(activeCompany)
+          .then((res) => setForms(res.data))
+          .catch((err) => enqueueSnackbar("Erro ao carregar formulários", { variant: "error" }))
+          .finally(() => setLoadingForms(false));
+      }
+    }
+  }, [activeCompany, currentTab]);
+
+  useEffect(() => {
+
+  const interval = setInterval(() => {
+    ProgressService.getProgress(activeCompany)
+      .then((res) => {
+        if (res.data && Object.keys(res.data).length > 0) {
+          setProgress(res.data);
+          setGeneratingAI(true);
+        }
+      })
+      .catch(console.error);
+  }, 5000);
+
+    return () => clearInterval(interval);
+  }, [generating]);
+
+  const handleViewWebsite = (page: SalesPage) => {
+    window.open(`https://roktune.duckdns.org/sales-pages/page/${page.id}`, "_blank");
+  };
+
+  const handleViewFormWebsite = (form: FormLead) => {
+    window.open(`https://roktune.duckdns.org/sales-pages//leads/form?apiKey=${form.apiKey}`, "_blank");
+  };
+
+  const handleEditPage = (page: SalesPage) => {
+    setEditingPage(page);
+  };
+
+  const handleDeletePage = async (id: string) => {
+    try {
+      await SalesPageService.delete(id);
+      setSalesPages((prev) => prev.filter((p) => p.id !== id));
+      enqueueSnackbar(t("marketing.capturePages.pageDeleted"), { variant: "success" });
+    } catch (error) {
+      console.error("Erro ao deletar landing page:", error);
+      enqueueSnackbar(t("marketing.capturePages.deleteError"), { variant: "error" });
+    } finally {
+      setEditingPage(null);
+    }
+  };
+
+  const handleDrag = (e: React.DragEvent<HTMLDivElement>, index: number) => {
+    e.dataTransfer.setData("sectionIndex", index.toString());
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, dropIndex: number) => {
+    const draggedIndex = parseInt(e.dataTransfer.getData("sectionIndex"));
+    if (!isNaN(draggedIndex)) {
+      const updated = [...sections];
+      const [removed] = updated.splice(draggedIndex, 1);
+      updated.splice(dropIndex, 0, removed);
+      setSections(updated);
+    }
+  };
+
+  const handleAddCustomSection = () => {
+    const trimmed = customSectionInput.trim();
+    if (trimmed && !sections.includes(trimmed)) {
+      const withoutFooter = sections.filter((s) => s !== "footer");
+      setSections([...withoutFooter, trimmed, "footer"]);
+      setCustomSectionInput("");
+    }
+  };
+
+  if (leadGenerationEnabled) {
+    return <LeadGeneration activeCompany={activeCompany} setModule={setModule} />;
+  }
+
+  return (
+    <Box sx={{
+      p: isMobile ? 1.5 : 3,
+      backgroundColor: '#ffffff',
+      minHeight: '100vh',
+    }}>
+      {/* Tabs */}
+        <Box sx={{
+          borderColor: 'divider',
+          mb: 2,
+          position: 'sticky',
+          background: 'linear-gradient(to bottom, #578acd 10%, #6192d4 40%, #669ee7 100%)',
+          zIndex: 9,
+          pt: 1,
+          color:'white',
+        }}>
+        <Tabs
+          value={currentTab}
+          onChange={(e, newValue) => setCurrentTab(newValue)}
+          variant="fullWidth"
+          sx={{
+            '& .MuiTabs-indicator': {
+              backgroundColor: '#ffffff',
+              height: 3
+            }
+          }}
+        >
+          <Tab
+            label={t("marketing.capturePages.salesPagesTab")}
+            sx={{
+              fontSize: '0.8rem',
+              fontWeight: 600,
+              textTransform: 'none',
+              minWidth: 0,
+              color:'#fbfbfb',
+              mt:-0.8,
+              '&.Mui-selected': { color: '#ffffff' }
+            }}
+          />
+          <Tab
+            label={t("marketing.capturePages.formsTab")}
+            sx={{
+              fontSize: '0.8rem',
+              fontWeight: 600,
+              textTransform: 'none',
+              minWidth: 0,
+              color:'#fbfbfb',
+              mt:-0.8,
+              '&.Mui-selected': { color: '#ffffff' }
+            }}
+          />
+        </Tabs>
+      </Box>
+      {/* Header */}
+      <Box sx={{
+        display: 'flex',
+        alignItems: 'center',
+        position: 'sticky',
+        top: 0,
+        backgroundColor: '#578acd0',
+        zIndex: 10,
+        pt: 4,
+        pb: 1,
+        pl:1,
+        pr:2
+      }}>
+        <IconButton onClick={() => setModule('')} sx={{ color: '#525252', mr: 1, mt:'-50px' }}>
+          <ArrowBackIos />
+        </IconButton>
+        <Box sx={{ ml: 'auto', display: 'flex', gap: 1, marginTop:'-50px' }}>
+          <PlusOutlined
+            style={{
+              fontSize: '13px',
+              color: 'white',
+              cursor: 'pointer',
+              transition: 'color 0.3s ease',
+              marginRight: '5px',
+              background:'#578acd',
+              padding: '6px',
+              borderRadius: '5px',
+            }}
+            onClick={() => setOpenForm(true)}
+          />
+          <FormatListBulletedOutlined
+            style={{
+              fontSize: '13px',
+              color: 'white',
+              cursor: 'pointer',
+              transition: 'color 0.3s ease',
+              marginRight: '5px',
+              background:'#578acd',
+              padding: '6px',
+              borderRadius: '5px',
+            }}
+            onClick={() => setLeadGenerationEnabled(true)}
+          />
+        </Box>
+      </Box>
+
+      {/* Content */}
+      {currentTab === 0 ? (
+        <Grid container spacing={2}>
+          {loadingPages ? (
+            Array.from({ length: 4 }).map((_, index) => (
+              <Grid item xs={6} key={index}>
+                <Card sx={{ borderRadius: '12px' }}>
+                  <Skeleton variant="rectangular" width="100%" height={120} />
+                  <CardContent>
+                    <Skeleton width="80%" height={20} />
+                    <Skeleton width="60%" height={16} sx={{ mt: 1 }} />
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))
+          ) : salesPages.length > 0 ? (
+            salesPages.map((page) => (
+              <Grid item xs={6} key={page.id}>
+                <Card
+                  sx={{
+                    borderRadius: '12px',
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
+                    transition: 'transform 0.2s, box-shadow 0.2s',
+                    '&:hover': {
+                      transform: 'translateY(-4px)',
+                      boxShadow: '0 8px 16px rgba(0,0,0,0.1)'
+                    }
+                  }}
+                >
+                  {page.screenshotUrl ? (
+                    <img
+                      src={page.screenshotUrl}
+                      alt={page.title}
+                      style={{
+                        width: '100%',
+                        height: 120,
+                        objectFit: 'cover',
+                        borderTopLeftRadius: '12px',
+                        borderTopRightRadius: '12px'
+                      }}
+                    />
+                  ) : (
+                    <Box sx={{
+                      height: 120,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: alpha('#578acd', 0.1)
+                    }}>
+                      <InsertDriveFileOutlined sx={{ color: alpha('#578acd', 0.5) }} />
+                    </Box>
+                  )}
+
+                  <CardContent sx={{ p: 2 }}>
+                    <Box sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      mb: 0.5
+                    }}>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{
+                          fontWeight: 600,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis'
+                        }}
+                      >
+                        {page.title}
+                      </Typography>
+                      <Box
+                        sx={{
+                          width: 8,
+                          height: 8,
+                          borderRadius: '50%',
+                          backgroundColor: page.isActive ? '#4caf50' : '#f44336',
+                          ml: 1,
+                          flexShrink: 0
+                        }}
+                      />
+                    </Box>
+
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden'
+                      }}
+                    >
+                      {page.description || t("marketing.capturePages.noDescription")}
+                    </Typography>
+
+                    <Box sx={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      mt: 1
+                    }}>
+                      <Chip
+                        label={`${page?.views === undefined ? 0 : page.views} views`}
+                        size="small"
+                        sx={{
+                          height: 20,
+                          fontSize: '0.6rem',
+                          backgroundColor: alpha('#578acd', 0.1)
+                        }}
+                      />
+                    </Box>
+                  </CardContent>
+
+                  <Box sx={{
+                    display: 'flex',
+                    p: 1,
+                    borderTop: `1px solid ${alpha('#578acd', 0.1)}`
+                  }}>
+                    <Button
+                      size="small"
+                      onClick={() => handleEditPage(page)}
+                      sx={{
+                        fontSize: '0.65rem',
+                        color: '#578acd',
+                        textTransform: 'none',
+                        flex: 1
+                      }}
+                    >
+                      {t('marketing.capturePages.editPage')}
+                    </Button>
+                    <Button
+                      size="small"
+                      onClick={() => handleViewWebsite(page)}
+                      sx={{
+                        fontSize: '0.65rem',
+                        color: '#578acd',
+                        textTransform: 'none',
+                        flex: 1
+                      }}
+                    >
+                      {t("marketing.capturePages.viewSalesPage")}
+                    </Button>
+                  </Box>
+                </Card>
+              </Grid>
+            ))
+          ) : (
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '100%',
+                p: 4,
+                textAlign: 'center'
+              }}
+            >
+              <InsertDriveFileOutlined sx={{
+                fontSize: 48,
+                color: alpha('#578acd', 0.3),
+                mb: 2
+              }} />
+              <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                {t("marketing.capturePages.noSalesPageFound")}
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                {t("marketing.capturePages.tryCreatingOne")}
+              </Typography>
+              <Button
+                variant="contained"
+                color="primary"
+                size="small"
+                startIcon={<PlusCircle size={16} />}
+                onClick={() => setOpenForm(true)}
+                sx={{
+                  backgroundColor: '#578acd',
+                  '&:hover': { backgroundColor: alpha('#578acd', 0.9) }
+                }}
+              >
+                {t("marketing.capturePages.createPage")}
+              </Button>
+            </Box>
+          )}
+        </Grid>
+      ) : (
+        <Grid container spacing={2}>
+          {loadingForms ? (
+            Array.from({ length: 4 }).map((_, index) => (
+              <Grid item xs={6} key={index}>
+                <Card sx={{ borderRadius: '12px' }}>
+                  <CardContent>
+                    <Skeleton width="80%" height={20} />
+                    <Skeleton width="60%" height={16} sx={{ mt: 1 }} />
+                    <Skeleton variant="rectangular" width="100%" height={80} sx={{ mt: 2 }} />
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))
+          ) : forms.length > 0 ? (
+            forms.map((form) => (
+              <Grid item xs={6} key={form.id}>
+                <Card
+                  sx={{
+                    borderRadius: '12px',
+                    boxShadow: '0 4px 12px rgba(0,0,0,0.05)',
+                    transition: 'transform 0.2s, box-shadow 0.2s',
+                    '&:hover': {
+                      transform: 'translateY(-4px)',
+                      boxShadow: '0 8px 16px rgba(0,0,0,0.1)'
+                    }
+                  }}
+                >
+                  <CardContent sx={{ p: 2 }}>
+                    <Typography
+                      variant="subtitle2"
+                      sx={{
+                        fontWeight: 600,
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis'
+                      }}
+                    >
+                      {form.title}
+                    </Typography>
+
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden'
+                      }}
+                    >
+                      {form.description || t("marketing.capturePages.noDescription")}
+                    </Typography>
+
+                    <Box sx={{ height: 80, mt: 1 }}>
+                      <FormSubmissionsChart submissions={form.formlead} />
+                    </Box>
+
+                    <Box sx={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      mt: 1
+                    }}>
+                      <Chip
+                        label={`${form.formlead.length} leads`}
+                        size="small"
+                        sx={{
+                          height: 20,
+                          fontSize: '0.6rem',
+                          backgroundColor: alpha('#578acd', 0.1)
+                        }}
+                      />
+                      <Typography variant="caption" color="text.secondary">
+                        {form.created_at ?
+                          new Date(form.created_at).toLocaleDateString("pt-BR", { day: '2-digit', month: 'short' }) :
+                          t("common.noDate")}
+                      </Typography>
+                    </Box>
+                  </CardContent>
+
+                  <Box sx={{
+                    display: 'flex',
+                    p: 1,
+                    borderTop: `1px solid ${alpha('#578acd', 0.1)}`
+                  }}>
+                    <Button
+                      size="small"
+                      onClick={() => handleViewFormWebsite(form)}
+                      sx={{
+                        fontSize: '0.65rem',
+                        color: '#578acd',
+                        textTransform: 'none',
+                        flex: 1
+                      }}
+                    >
+                      {t("marketing.capturePages.viewForm")}
+                    </Button>
+                  </Box>
+                </Card>
+              </Grid>
+            ))
+          ) : (
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '100%',
+                p: 4,
+                textAlign: 'center'
+              }}
+            >
+              <FormatListBulletedOutlined sx={{
+                fontSize: 48,
+                color: alpha('#578acd', 0.3),
+                mb: 2
+              }} />
+              <Typography variant="subtitle1" sx={{ mb: 1 }}>
+                {t("marketing.capturePages.noFormFound")}
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                {t("marketing.capturePages.tryCreatingOneForm")}
+              </Typography>
+              <Button
+                variant="contained"
+                color="primary"
+                size="small"
+                startIcon={<PlusCircle size={16} />}
+                onClick={() => setLeadGenerationEnabled(true)}
+                sx={{
+                  backgroundColor: '#578acd',
+                  '&:hover': { backgroundColor: alpha('#578acd', 0.9) }
+                }}
+              >
+                {t("marketing.capturePages.createForm")}
+              </Button>
+            </Box>
+          )}
+        </Grid>
+      )}
+
+<Dialog
+  open={openForm}
+  onClose={() => setOpenForm(false)}
+  fullScreen={isMobile}
+>
+        {generatingAI ? (
+          <Box
+            mt={4}
+            p={4}
+            borderRadius="12px"
+            bgcolor="rgba(255, 255, 255, 0.9)"
+            boxShadow="0 8px 32px rgba(0, 0, 0, 0.05)"
+            border="1px solid rgba(0, 0, 0, 0.05)"
+            sx={{
+              backdropFilter: 'blur(8px)',
+              background: 'linear-gradient(135deg, rgba(255,255,255,0.96) 0%, rgba(248,250,252,0.96) 100%)'
+            }}
+          >
+            <Typography
+              variant="h6"
+              gutterBottom
+              sx={{
+                fontWeight: 600,
+                color: 'text.primary',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1
+              }}
+            >
+              <CircularProgress
+                size={24}
+                thickness={4}
+                sx={{
+                  color: 'primary.main',
+                  animationDuration: '800ms'
+                }}
+              />
+              Generating your template...
+            </Typography>
+
+            <Box
+              component="ul"
+              sx={{
+                pl: 0,
+                mt: 2,
+                mb: 0,
+                display: 'grid',
+                gap: 1.5
+              }}
+            >
+              {sections.map((section) => {
+                const status = progress?.[section];
+                const label = sectionLabels?.[section] || section;
+
+                return (
+                  <Box
+                    key={section}
+                    component="li"
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 2,
+                      p: 1.5,
+                      borderRadius: '8px',
+                      transition: 'all 0.3s ease',
+                      backgroundColor: status === 'loading' ? 'rgba(0, 100, 255, 0.03)' : 'transparent',
+                      '&:hover': {
+                        backgroundColor: 'rgba(0, 0, 0, 0.02)'
+                      }
+                    }}
+                  >
+                    <Box sx={{ position: 'relative', width: 24, height: 24 }}>
+                      {status === 'loading' ? (
+                        <CircularProgress
+                          size={24}
+                          thickness={4}
+                          sx={{
+                            color: 'primary.main',
+                            position: 'absolute',
+                            animationDuration: '800ms'
+                          }}
+                        />
+                      ) : status === 'done' ? (
+                        <Box
+                          sx={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: '50%',
+                            backgroundColor: 'success.light',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center'
+                          }}
+                        >
+                          <Check
+                            sx={{
+                              color: 'success.contrastText',
+                              fontSize: 16
+                            }}
+                          />
+                        </Box>
+                      ) : status === 'error' ? (
+                        <Box
+                          sx={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: '50%',
+                            backgroundColor: 'error.light',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center'
+                          }}
+                        >
+                          <Close
+                            sx={{
+                              color: 'error.contrastText',
+                              fontSize: 16
+                            }}
+                          />
+                        </Box>
+                      ) : (
+                        <Box
+                          sx={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: '50%',
+                            backgroundColor: 'action.disabledBackground',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center'
+                          }}
+                        >
+                          <AccessTime
+                            sx={{
+                              color: 'action.disabled',
+                              fontSize: 16
+                            }}
+                          />
+                        </Box>
+                      )}
+                    </Box>
+
+                    <Typography
+                      variant="body1"
+                      sx={{
+                        fontWeight: 500,
+                        color: status === 'error' ? 'error.main' : 'text.primary',
+                        flexGrow: 1
+                      }}
+                    >
+                      {label}
+                    </Typography>
+
+                    {status === 'loading' && (
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: 'text.secondary',
+                          fontFeatureSettings: '"tnum"'
+                        }}
+                      >
+                        Processing...
+                      </Typography>
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+
+            <Box
+              sx={{
+                mt: 3,
+                pt: 2,
+                borderTop: '1px solid',
+                borderColor: 'divider',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center'
+              }}
+            >
+              <Typography variant="caption" sx={{ color: 'text.secondary' }}>
+                {sections.filter(s => progress?.[s] === 'done' || progress?.[s] === 'error').length} of {sections.length} completed
+              </Typography>
+
+              <LinearProgress
+                variant="determinate"
+                value={(sections.filter(s => progress?.[s] === 'done' || progress?.[s] === 'error').length / sections.length) * 100}
+                sx={{
+                  height: 6,
+                  borderRadius: 3,
+                  width: '60%',
+                  backgroundColor: 'action.selected',
+                  '& .MuiLinearProgress-bar': {
+                    borderRadius: 3,
+                    backgroundColor: 'primary.main'
+                  }
+                }}
+              />
+            </Box>
+          </Box>
+        ) : (
+          <>
+  <DialogTitle
+    sx={{
+      backgroundColor: "#578acd",
+      color: "#ffffff",
+      display: "flex",
+      alignItems: "center",
+      py: 1.5,
+    }}
+  >
+    <IconButton
+      edge="start"
+      color="inherit"
+      onClick={() => setOpenForm(false)}
+      sx={{ mr: 1 }}
+    >
+      <ArrowLeft size={20} />
+    </IconButton>
+    <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+      {t("marketing.capturePages.createSalesPage")}
+    </Typography>
+  </DialogTitle>
+
+  <DialogContent sx={{ p: 2 }}>
+    <ToggleButtonGroup
+      fullWidth
+      exclusive
+      value={useAI ? "ai" : "manual"}
+      onChange={(_, val) => {
+        if (val !== null) setUseAI(val === "ai");
+      }}
+      size="small"
+      sx={{ mb: 2, mt:3 }}
+    >
+      <ToggleButton style={{fontSize:'7.5pt'}} value="manual">
+        {t("marketing.templateDialog.chooseTemplate")}
+      </ToggleButton>
+      <ToggleButton style={{fontSize:'7.5pt'}} value="ai">
+        {t("marketing.templateDialog.createAiTemplate")}
+      </ToggleButton>
+    </ToggleButtonGroup>
+
+    <TextField
+      label={t("marketing.templateDialog.titleLabel")}
+      fullWidth
+      margin="dense"
+      size="small"
+      sx={{ mb: 2 }}
+      value={newPage.title}
+      onChange={(e) =>
+        setNewPage((prev) => ({ ...prev, title: e.target.value }))
+      }
+    />
+
+    {useAI ? (
+      <>
+      <TextField
+        label={t("marketing.templateDialog.aiPromptHint")}
+        fullWidth
+        multiline
+        rows={4}
+        size="small"
+        value={aiPrompt}
+        onChange={(e) => setAiPrompt(e.target.value)}
+      />
+      <FormGroup sx={{ mt: 3 }}>
+        <Typography fontWeight={600} mb={1}>{t("marketing.templateDialog.chooseSections")}</Typography>
+        <Box>
+          {sections.map((section, index) => (
+            <Box
+              key={section + index}
+              draggable
+              onDragStart={(e) => handleDrag(e, index)}
+              onDragOver={(e) => e.preventDefault()}
+              onDrop={(e) => handleDrop(e, index)}
+              sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1, p: 1, border: '1px dashed #ccc', borderRadius: 1 }}
+            >
+              <Checkbox
+                checked
+                onChange={() => {
+                  const updated = sections.filter((s) => s !== section);
+                  setSections(updated);
+                }}
+              />
+              <Typography>{sectionLabels[section] || section}</Typography>
+              <Typography variant="caption" sx={{ ml: 'auto', color: '#888', cursor:'pointer' }}>::  ::</Typography>
+            </Box>
+          ))}
+        </Box>
+      </FormGroup>
+
+      <Box mt={3}>
+        <Typography fontWeight={500} mb={1}>{t("marketing.templateDialog.addMoreSections")}</Typography>
+        <Box display="flex" gap={1} alignItems="center">
+          <TextField
+            fullWidth
+            value={customSectionInput}
+            onChange={(e) => setCustomSectionInput(e.target.value)}
+            placeholder="Ex: FAQ, Newsletter..."
+            margin="dense"
+          />
+          <Button
+            variant="contained"
+            color="primary"
+            sx={{ height: '55px', borderTopLeftRadius:'0px', borderBottomLeftRadius:'0px', whiteSpace: 'nowrap', mt: '4px', marginLeft:'-8px' }}
+            onClick={handleAddCustomSection}
+          >
+            <PlusCircle size={30}/>
+          </Button>
+        </Box>
+      </Box>
+      </>
+    ) : (
+      <>
+        <TextField
+          label={t("marketing.templateDialog.descriptionLabel")}
+          fullWidth
+          margin="dense"
+          size="small"
+          multiline
+          rows={2}
+          sx={{ mb: 3 }}
+          value={newPage.description}
+          onChange={(e) =>
+            setNewPage((prev) => ({ ...prev, description: e.target.value }))
+          }
+        />
+
+        <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
+          {t("marketing.templateDialog.chooseTemplate")}
+        </Typography>
+
+        <Grid container spacing={1.5}>
+          {loadingTemplates
+            ? Array.from({ length: 6 }).map((_, index) => (
+                <Grid item xs={6} key={index}>
+                  <Card>
+                    <Skeleton variant="rectangular" width="100%" height={100} />
+                    <CardContent sx={{ p: 1 }}>
+                      <Skeleton width="80%" height={20} />
+                    </CardContent>
+                  </Card>
+                </Grid>
+              ))
+            : templates.map((template) => (
+                <Grid item xs={6} key={template.id}>
+                  <Card
+                    onClick={() => setSelectedTemplate(template)}
+                    sx={{
+                      borderRadius: "8px",
+                      border:
+                        selectedTemplate?.id === template.id
+                          ? "2px solid #578acd"
+                          : "1px solid rgba(0, 0, 0, 0.1)",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <img
+                      src={template.screenshotUrl}
+                      alt={template.name}
+                      style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                      }}
+                    />
+                    <CardContent sx={{ p: 1 }}>
+                      <Typography variant="caption" fontWeight={600}>
+                        {template.name}
+                      </Typography>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              ))}
+        </Grid>
+      </>
+    )}
+  </DialogContent>
+  </>
+  )}
+  <DialogActions sx={{ p: 2 }}>
+    <Button
+      variant="contained"
+      disabled={useAI ? !aiPrompt : !selectedTemplate}
+      onClick={async () => {
+        if (useAI) {
+          setGeneratingAI(true);
+
+          try {
+            const res = await SalesPageService.postAiTemplate({
+              title: newPage.title,
+              description: newPage.description,
+              aiPrompt: aiPrompt,
+              sections: sections,
+              companyId: activeCompany,
+            });
+
+            setPreviewUrl(
+              `https://roktune.duckdns.org/sales-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${encodeURIComponent(
+                newPage.title
+              )}`
+            );
+          } catch (err) {
+            enqueueSnackbar("Erro ao gerar template com IA", {
+              variant: "error",
+            });
+          } finally {
+            setGeneratingAI(false);
+          }
+
+        } else {
+          setOpenForm(false);
+          setPreviewUrl(
+            `https://roktune.duckdns.org/sales-pages/preview?type=${selectedTemplate?.type}&companyId=${activeCompany}&title=${encodeURIComponent(
+              newPage.title
+            )}`
+          );
+        }
+      }}
+      sx={{ backgroundColor: "#578acd" }}
+    >
+      {useAI
+        ? generatingAI
+          ? <CircularProgress size={20} />
+          : t("marketing.templateDialog.generateAiTemplate")
+        : t("marketing.templateDialog.viewAndEdit")}
+    </Button>
+
+  </DialogActions>
+</Dialog>
+
+{/* Preview Dialog */}
+{previewUrl && (
+  <Dialog open={true} fullScreen={isMobile} onClose={() => setPreviewUrl(null)}>
+    <DialogTitle>{t("marketing.previewDialog.title")}</DialogTitle>
+    <DialogContent>
+      <iframe
+        id="previewIframe"
+        src={previewUrl}
+        width="100%"
+        height={isMobile ? "100%" : "600px"}
+        style={{ border: "none" }}
+      />
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={() => setPreviewUrl(null)}>
+        {t("common.cancel")}
+      </Button>
+      <Button
+        variant="contained"
+        disabled={creatingSalesPage}
+        onClick={async () => {
+          setCreatingSalesPage(true);
+
+          const iframe = document.getElementById("previewIframe") as HTMLIFrameElement;
+          const saveButton = iframe?.contentDocument?.getElementById("saveButton") as HTMLButtonElement;
+
+          if (saveButton) saveButton.click();
+
+          await new Promise((res) => setTimeout(res, 10000));
+
+          try {
+            await SalesPageService.post({
+              companyId: activeCompany,
+              title: newPage.title,
+              description: newPage.description,
+              aiPrompt: aiPrompt,
+              sections,
+            });
+
+            enqueueSnackbar(t("marketing.capturePages.pageCreated"), {
+              variant: "success",
+            });
+
+            setPreviewUrl(null);
+            setOpenForm(false);
+            setNewPage({ title: "", description: "" });
+            setSelectedTemplate(null);
+
+            const updated = await SalesPageService.getSalesPages(activeCompany);
+            setSalesPages(updated.data);
+          } catch (error) {
+            enqueueSnackbar("Erro ao criar página", { variant: "error" });
+          } finally {
+            setCreatingSalesPage(false);
+          }
+        }}
+      >
+        {creatingSalesPage ? (
+          <CircularProgress size={20} />
+        ) : (
+          t("marketing.previewDialog.createSalesPage")
+        )}
+      </Button>
+
+    </DialogActions>
+  </Dialog>
+    )}
+
+    <EditDialog
+      open={Boolean(editingPage)}
+      landingPage={editingPage}
+      onClose={() => setEditingPage(null)}
+      onDelete={handleDeletePage}
+    />
+    </Box>
+  );
+};
+
+export default MobileCapturePages;

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -757,15 +757,18 @@
       "createLandingPage": "Landing Page",
       "createForm": "Capture Form",
       "landingPagesTab": "Landing Pages",
+      "salesPagesTab": "Sales Pages",
       "formsTab": "Capture Forms",
       "noLandingPageFound": "No landing pages found.",
       "tryCreatingOne": "Try creating a new page to find potential customers",
       "createPage": "Create New Landing Page",
+      "createSalesPage": "Create New Sales Page",
       "noFormFound": "No forms found.",
       "tryCreatingOneForm": "Try creating a new form to find potential customers",
       "createPageForm": "Create New Capture Form",
       "viewDetails": "View Details",
       "viewLandingPage": "View Landing Page",
+      "viewSalesPage": "View Sales Page",
       "viewForm": "View Form",
       "noDescription": "No description",
       "createdAt": "Created on",
@@ -817,6 +820,7 @@
       "instructionText5": "Click and hold to drag images",
       "instructionText6": "Alt + right-click to create links",
       "createLandingPage": "Create landing page!"
+      "createSalesPage": "Create sales page!"
     },
     "detailsDialog": {
       "title": "Landing Page Details",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -763,15 +763,18 @@
       "createLandingPage": "Landing Page",
       "createForm": "Formulário de Captura",
       "landingPagesTab": "Landing Pages",
+      "salesPagesTab": "Sales Pages",
       "formsTab": "Formulários",
       "noLandingPageFound": "Nenhuma landing page encontrada.",
       "tryCreatingOne": "Crie uma nova página.",
       "createPage": "Criar Página",
+      "createSalesPage": "Criar Sales Page",
       "noFormFound": "Nenhum formulário encontrado.",
       "tryCreatingOneForm": "Tente criar um novo formulário para encontrar clientes",
       "createPageForm": "Criar novo formulário",
       "viewDetails": "Ver Detalhes",
       "viewLandingPage": "Ver Landing Page",
+      "viewSalesPage": "Ver Sales Page",
       "viewForm": "Ver Formulário",
       "noDescription": "Sem descrição",
       "createdAt": "Criado em",
@@ -822,6 +825,7 @@
       "instructionText5": "Clique e segure para arrastar as imagens",
       "instructionText6": "Alt + clique com o botão direito para criar links",
       "createLandingPage": "Criar landing page!",
+      "createSalesPage": "Criar sales page!"
       "generateAiTemplate": "Gerar Template IA"
     },
     "detailsDialog": {

--- a/src/services/sales-page.service.ts
+++ b/src/services/sales-page.service.ts
@@ -1,0 +1,32 @@
+import http from './http-business.ts';
+
+class SalesPageService {
+  static get() {
+    return http.get(`/sales-pages/templates`);
+  }
+
+  static getSalesPages(companyId) {
+    return http.get(`/sales-pages/${companyId}`);
+  }
+
+  static getSalesComponents() {
+    return http.get(`/sales-pages/components`);
+  }
+
+  static post(body) {
+    return http.post(`/sales-pages/activate`, body);
+  }
+
+  static postAiTemplate(body) {
+    return http.post(`/sales-pages/ai-templates`, body);
+  }
+
+  static update(id, body) {
+    return http.patch(`/sales-pages/${id}`, body);
+  }
+
+  static delete(id) {
+    return http.delete(`/sales-pages/${id}`);
+  }
+}
+export default SalesPageService;


### PR DESCRIPTION
## Summary
- add SalesPageService for backend endpoints
- add Sales Pages components (desktop and mobile)
- integrate Sales Pages module into marketing dashboards
- add translations for sales pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685422e405788321a308cd5e3a776a37