### PR TITLE
Implement company loading overlay

### DIFF
--- a/src/pages/Dashboard/dashboard.tsx
+++ b/src/pages/Dashboard/dashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { DashboardContainer, DashboardContainerIcon, DashboardContainerShowed } from './styles.ts';
+import { CircularProgress } from '@mui/material';
+import { DashboardContainer, DashboardContainerIcon, DashboardContainerShowed, LoadingOverlay } from './styles.ts';
 import { useLocalStorage } from '../../hooks/useLocalStorage.ts';
 import AllInOneService from '../../services/all-in-one.service.ts';
 import Payments from '../../components/payments/index.tsx';
@@ -34,6 +35,7 @@ const Dashboard: React.FC = () => {
   const [hasNoCompanies, setHasNoCompanies] = useState(false);
   const [modulesUpdating, setModulesUpdating] = useState(false);
   const [newCompany, setNewCompany] = useState(false);
+  const [loadingCompanies, setLoadingCompanies] = useState(true);
 
   const { userData, setUserData } = useUser();
 
@@ -81,8 +83,34 @@ useEffect(() => {
     });
 }, [token, hasNoCompanies]);
 
+useEffect(() => {
+  if (activeCompany) {
+    setLoadingCompanies(false);
+    return;
+  }
+  setLoadingCompanies(true);
+}, [activeCompany]);
+
+useEffect(() => {
+  if (!token) return;
+  const timer = setTimeout(() => {
+    if (!activeCompany) {
+      localStorage.removeItem('accessToken');
+      window.location.replace('/');
+    }
+  }, 10000);
+
+  return () => clearTimeout(timer);
+}, [activeCompany, token]);
+
   return (
     <DashboardContainer>
+
+      {loadingCompanies && (
+        <LoadingOverlay>
+          <CircularProgress sx={{ color: '#578acd' }} />
+        </LoadingOverlay>
+      )}
 
       {window.outerWidth > 600 ? (
         <Sidebar

--- a/src/pages/Dashboard/styles.ts
+++ b/src/pages/Dashboard/styles.ts
@@ -54,3 +54,16 @@ export const DashboardContainerIcon = styled(IoMdMenu)`
   border-radius: 50px;
   z-index: 1;
 `;
+
+export const LoadingOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background: rgba(255, 255, 255, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+`;


### PR DESCRIPTION
## Summary
- add a full-screen loading overlay when company data is not ready
- automatically log out after 10s if no company was loaded

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68594fda21b083219765ba311dee6976