### PR TITLE
Add currency selector for products

### DIFF
--- a/src/components/products/index.tsx
+++ b/src/components/products/index.tsx
@@ -13,6 +13,7 @@ import {
     IconButton,
     Chip,
     Box,
+    MenuItem,
   } from '@mui/material';
   import { Close, Delete } from '@mui/icons-material';
 import ProductService from '../../services/product.service.ts'
@@ -318,12 +319,21 @@ const ProductModal: React.FC<{
   const { t } = useTranslation();
   const { enqueueSnackbar } = useSnackbar();
 
+  const currencyOptions = [
+    { value: 'USD', label: 'USD - US Dollar' },
+    { value: 'EUR', label: 'EUR - Euro' },
+    { value: 'BRL', label: 'BRL - Brazilian Real' },
+    { value: 'GBP', label: 'GBP - British Pound' },
+    { value: 'JPY', label: 'JPY - Japanese Yen' },
+  ];
+
   const [formData, setFormData] = useState({
     id: '',
     name: '',
     description: '',
     category: '',
     price: '',
+    currency: 'USD',
     cost: '',
     quantityInStock: 0,
     height: '',
@@ -339,7 +349,7 @@ const ProductModal: React.FC<{
 
   const [images, setImages] = useState<string[]>([]);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (e: any) => {
     const { name, value, type, checked } = e.target;
     setFormData((prevData) => ({
       ...prevData,
@@ -355,6 +365,7 @@ const ProductModal: React.FC<{
         description: product.description || '',
         category: product.category || '',
         price: product.price || '',
+        currency: product.currency || 'USD',
         cost: product.cost || '',
         quantityInStock: product.quantityInStock || 0,
         height: product.height || '',
@@ -377,6 +388,7 @@ const ProductModal: React.FC<{
       description: '',
       category: '',
       price: '',
+      currency: 'USD',
       cost: '',
       quantityInStock: 0,
       height: '',
@@ -510,6 +522,22 @@ const ProductModal: React.FC<{
                 onChange={handleInputChange}
                 required
               />
+            </Grid>
+            <Grid item xs={6}>
+              <TextField
+                select
+                fullWidth
+                label={t('products.forms.currency')}
+                name="currency"
+                value={formData.currency}
+                onChange={handleInputChange}
+              >
+                {currencyOptions.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </TextField>
             </Grid>
             <Grid item xs={6}>
               <TextField

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -255,6 +255,7 @@
       "price": "Price",
       "cost": "Cost",
       "quantityInStock": "Quantity in Stock",
+      "currency": "Currency",
       "productImages": "Product Images",
       "uploadImages": "Upload Images",
       "cancel": "Cancel",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -261,6 +261,7 @@
       "price": "Preço",
       "cost": "Custo",
       "quantityInStock": "Quantidade em Estoque",
+      "currency": "Moeda",
       "productImages": "Imagens do Produto",
       "uploadImages": "Enviar Imagens",
       "cancel": "Cancelar",


### PR DESCRIPTION
## Summary
- let users choose currency when creating or editing products
- store currency in form state and reset
- provide translations for currency label

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6875070e480c8321aeae47c5a0495386