### PR TITLE
Add payment table view

### DIFF
--- a/src/data/en.json
+++ b/src/data/en.json
@@ -341,7 +341,11 @@
     "averageTicket": "Average Ticket",
     "taxes": "Taxes",
     "aiInsights": "AI Analysis",
-    "tooltipText": "Payments are recorded automatically through integration with other system modules that detect new transactions. To add or adjust information manually, please contact our support team."
+    "tooltipText": "Payments are recorded automatically through integration with other system modules that detect new transactions. To add or adjust information manually, please contact our support team.",
+    "image": "Product Image",
+    "currency": "Currency",
+    "paymentDate": "Payment Date",
+    "status": "Status"
   },
   "customers": {
     "title": "Customer Session",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -347,7 +347,11 @@
     "averageTicket": "Ticket Médio",
     "taxes": "Impostos",
     "aiInsights": "Análise com IA",
-    "tooltipText": "Os pagamentos são registrados automaticamente por meio da integração com outros módulos do sistema que detectam novas transações. Para adicionar ou ajustar informações manualmente, por favor, entre em contato com nossa equipe de suporte."
+    "tooltipText": "Os pagamentos são registrados automaticamente por meio da integração com outros módulos do sistema que detectam novas transações. Para adicionar ou ajustar informações manualmente, por favor, entre em contato com nossa equipe de suporte.",
+    "image": "Imagem do Produto",
+    "currency": "Moeda",
+    "paymentDate": "Data do Pagamento",
+    "status": "Status"
   },
   "customers": {
     "title": "Sessão de Clientes",

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -2,10 +2,13 @@ import http from './http-business.ts';
 
 class PaymentService {
     static get(data: string) {
-		return http.get(`/payment/${data}`);
-	}
+                return http.get(`/payment/${data}`);
+        }
     static glance(data: string) {
-		return http.get(`/payment/glance/${data}`);
-	}
+                return http.get(`/payment/glance/${data}`);
+        }
+    static withProduct(companyId: string) {
+                return http.get(`/payment/with-product/${companyId}`);
+        }
 }
 export default PaymentService;


### PR DESCRIPTION
## Summary
- add translations for payment columns
- support `withProduct` endpoint in payment service
- show payment table with product info

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68752621eb208321b8ab94b737252fe6