### PR TITLE
Add open conversation button in chatbot history

### DIFF
--- a/src/components/marketing/chatbot/ChatHistoryModal.tsx
+++ b/src/components/marketing/chatbot/ChatHistoryModal.tsx
@@ -14,19 +14,21 @@ import {
   Stack,
   Grid,
   Chip,
-  IconButton
+  IconButton,
+  Tooltip
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import ChatbotService from '../../../services/chatbot.service.ts';
-import { AccessTime, Delete, DeleteForeverOutlined, RemoveRedEyeOutlined } from '@mui/icons-material';
+import { AccessTime, Delete, DeleteForeverOutlined, RemoveRedEyeOutlined, Launch } from '@mui/icons-material';
 
 interface ChatHistoryModalProps {
   open: boolean;
   onClose: () => void;
   botId: string | null;
+  botSlug: string | null;
 }
 
-const ChatHistoryModal: React.FC<ChatHistoryModalProps> = ({ open, onClose, botId }) => {
+const ChatHistoryModal: React.FC<ChatHistoryModalProps> = ({ open, onClose, botId, botSlug }) => {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [threads, setThreads] = useState<any[]>([]);
@@ -122,6 +124,17 @@ const renderThreadsList = () => {
               >
                 <RemoveRedEyeOutlined fontSize="small" />
               </IconButton>
+              {botSlug && (
+                <Tooltip title={t('chatbot.openConversation')} arrow>
+                  <IconButton
+                    size="small"
+                    onClick={() => window.open(`https://roktune.duckdns.org/chatbot/s/${botSlug}?threadId=${thread.threadId}`, '_blank')}
+                    sx={{ position: 'absolute', bottom: 6, right: 52 }}
+                  >
+                    <Launch fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
               <Card
                 sx={{
                   height: '100%',

--- a/src/components/marketing/chatbot/index.tsx
+++ b/src/components/marketing/chatbot/index.tsx
@@ -70,6 +70,7 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
   const [loadingBots, setLoadingBots] = useState(true);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyBotId, setHistoryBotId] = useState<string | null>(null);
+  const [historyBotSlug, setHistoryBotSlug] = useState<string | null>(null);
   const navigate = useNavigate();
 
   const handleInputChange = (e) => {
@@ -193,14 +194,16 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
     setCreatingBot(true);
   };
 
-  const handleOpenHistory = (botId: string) => {
+  const handleOpenHistory = (botId: string, botSlug: string) => {
     setHistoryBotId(botId);
+    setHistoryBotSlug(botSlug);
     setHistoryOpen(true);
   };
 
   const handleCloseHistory = () => {
     setHistoryOpen(false);
     setHistoryBotId(null);
+    setHistoryBotSlug(null);
   };
 
   const handleUpdateBot = async () => {
@@ -958,10 +961,10 @@ return (
                 gap: 1,
                 borderTop: '1px solid #F1F5F9'
               }}>
-                                <Button
+                <Button
                   size="small"
                   variant="outlined"
-                  onClick={() => handleOpenHistory(bot.id)}
+                  onClick={() => handleOpenHistory(bot.id, bot.slug)}
                   sx={{
                     borderRadius: '10px',
                     fontWeight: 600,
@@ -1024,6 +1027,7 @@ return (
       open={historyOpen}
       onClose={handleCloseHistory}
       botId={historyBotId}
+      botSlug={historyBotSlug}
     />
   </Box>
 );

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -1124,6 +1124,7 @@
     "historyTitle": "Conversation History",
     "noHistory": "No conversation history",
     "conversation": "Conversation",
+    "openConversation": "Open Conversation",
     "captureLeads": "Capture leads",
     "captureLeadsTooltip": "The bot will capture leads automatically",
     "createImages": "Create Images",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -1131,6 +1131,7 @@
     "historyTitle": "Histórico de Conversa",
     "noHistory": "Nenhum histórico de conversa",
     "conversation": "Conversa",
+    "openConversation": "Abrir Conversa",
     "captureLeads": "Capturar leads",
     "captureLeadsTooltip": "O Bot capturará leads automaticamente",
     "createImages": "Criar Imagens",


### PR DESCRIPTION
## Summary
- support slug on chat history modal to create direct link
- expose conversation link button in history cards
- update translation files with `openConversation` entry

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687529b2881083218633a6486c73aee4