### PR TITLE
Add product selection modal for chatbot

### DIFF
--- a/src/components/marketing/chatbot/ProductsSelectModal.tsx
+++ b/src/components/marketing/chatbot/ProductsSelectModal.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Checkbox,
+  List,
+  ListItem,
+  ListItemAvatar,
+  Avatar,
+  ListItemText,
+  Typography,
+  Box
+} from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import ProductService from '../../../services/product.service.ts';
+
+interface Product {
+  id: string;
+  name: string;
+  description: string;
+  images?: string[];
+  instruction?: string;
+}
+
+interface ProductsSelectModalProps {
+  open: boolean;
+  onClose: () => void;
+  companyId: string;
+  selected: string[];
+  onChange: (ids: string[]) => void;
+}
+
+const ProductsSelectModal: React.FC<ProductsSelectModalProps> = ({ open, onClose, companyId, selected, onChange }) => {
+  const { t } = useTranslation();
+  const [products, setProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    if (open && companyId) {
+      ProductService.get(companyId)
+        .then((res) => setProducts(res.data || []))
+        .catch(() => setProducts([]));
+    }
+  }, [open, companyId]);
+
+  const handleToggle = (id: string) => {
+    const exists = selected.includes(id);
+    if (exists) {
+      onChange(selected.filter((p) => p !== id));
+    } else {
+      onChange([...selected, id]);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>{t('products.selectProducts', 'Select Products')}</DialogTitle>
+      <DialogContent dividers>
+        {products.length === 0 ? (
+          <Typography variant="body2">{t('products.noProducts', 'No products')}</Typography>
+        ) : (
+          <List>
+            {products.map((product) => (
+              <ListItem key={product.id} alignItems="flex-start">
+                <Checkbox
+                  checked={selected.includes(product.id)}
+                  onChange={() => handleToggle(product.id)}
+                />
+                <ListItemAvatar>
+                  <Avatar src={product.images?.[0]} />
+                </ListItemAvatar>
+                <ListItemText
+                  primary={product.name}
+                  secondary={
+                    <Box>
+                      <Typography variant="body2" color="text.secondary">
+                        {product.description}
+                      </Typography>
+                      {product.instruction && (
+                        <Typography variant="caption" display="block">
+                          {product.instruction}
+                        </Typography>
+                      )}
+                    </Box>
+                  }
+                />
+              </ListItem>
+            ))}
+          </List>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>{t('sidepanel.close', 'Close')}</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ProductsSelectModal;

--- a/src/components/marketing/chatbot/index.tsx
+++ b/src/components/marketing/chatbot/index.tsx
@@ -36,6 +36,7 @@ import {
   History as HistoryIcon
 } from '@mui/icons-material';
 import ChatHistoryModal from './ChatHistoryModal.tsx';
+import ProductsSelectModal from './ProductsSelectModal.tsx';
 import ChatbotService from '../../../services/chatbot.service.ts';
 import { useNavigate } from 'react-router-dom';
 import { IoIosArrowBack } from 'react-icons/io';
@@ -49,10 +50,12 @@ const initialBotConfig = {
   createImages: false,
   createPages: false,
   createDocuments: false,
+  sellProducts: false,
   connectWhatsapp: false,
   welcomeMessage: '',
   pdfFiles: [],
-  profileImage: null
+  profileImage: null,
+  selectedProducts: [] as string[]
 };
 
 export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: string) => void }> = ({ activeCompany, setModule }) => {
@@ -71,6 +74,7 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyBotId, setHistoryBotId] = useState<string | null>(null);
   const [historyBotSlug, setHistoryBotSlug] = useState<string | null>(null);
+  const [productsModalOpen, setProductsModalOpen] = useState(false);
   const navigate = useNavigate();
 
   const handleInputChange = (e) => {
@@ -154,6 +158,8 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
       formData.append('captureLeads', botConfig.captureLeads);
       formData.append('createImages', botConfig.createImages);
       formData.append('createDocuments', botConfig.createDocuments);
+      formData.append('sellProducts', botConfig.sellProducts);
+      formData.append('products', JSON.stringify(botConfig.selectedProducts));
       formData.append('createPages', botConfig.createPages);
 
       if (botConfig.profileImage) {
@@ -188,8 +194,10 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
       captureLeads: bot.captureLeads,
       createImages: bot.createImages,
       createDocuments: bot.createDocuments,
+      sellProducts: bot.sellProducts,
       createPages: bot.createPages,
-      profileImage: bot.profileImage || null
+      profileImage: bot.profileImage || null,
+      selectedProducts: bot.products || []
     });
     setCreatingBot(true);
   };
@@ -217,6 +225,8 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
       formData.append('captureLeads', botConfig.captureLeads);
       formData.append('createImages', botConfig.createImages);
       formData.append('createDocuments', botConfig.createDocuments);
+      formData.append('sellProducts', botConfig.sellProducts);
+      formData.append('products', JSON.stringify(botConfig.selectedProducts));
       formData.append('createPages', botConfig.createPages);
 
       if (typeof botConfig.profileImage === 'string' && botConfig.profileImage.startsWith('http')) {
@@ -460,6 +470,20 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
                       <Tooltip title={t('chatbot.createDocumentsTooltip')}>
                         <HelpIcon sx={{ ml: 1, fontSize: 18, color: '#94A3B8' }} />
                       </Tooltip>
+                    </Box>
+                    <Box display="flex" alignItems="center" mt={0} mb={1}>
+                      <Checkbox
+                        checked={botConfig.sellProducts}
+                        onChange={()=>{handleCheckboxChange('sellProducts')}}
+                        color="primary"
+                        sx={{ '& .MuiSvgIcon-root': { fontSize: 24 } }}
+                      />
+                      <Typography variant="body2">{t('sell_products')}</Typography>
+                    </Box>
+                    <Box display="flex" alignItems="center" mt={0} mb={1}>
+                      <Button variant="outlined" onClick={()=> setProductsModalOpen(true)}>
+                        {t('products.selectProducts', 'Select Products')}
+                      </Button>
                     </Box>
                     <Box display="flex" alignItems="center" gap={2} mt={0} mb={1}>
                       <Button
@@ -709,6 +733,13 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
           </Box>
         </Box>
       </Box>
+      <ProductsSelectModal
+        open={productsModalOpen}
+        onClose={() => setProductsModalOpen(false)}
+        companyId={activeCompany}
+        selected={botConfig.selectedProducts}
+        onChange={(ids) => setBotConfig({ ...botConfig, selectedProducts: ids })}
+      />
     );
   }
 
@@ -1028,6 +1059,13 @@ return (
       onClose={handleCloseHistory}
       botId={historyBotId}
       botSlug={historyBotSlug}
+    />
+    <ProductsSelectModal
+      open={productsModalOpen}
+      onClose={() => setProductsModalOpen(false)}
+      companyId={activeCompany}
+      selected={botConfig.selectedProducts}
+      onChange={(ids) => setBotConfig({ ...botConfig, selectedProducts: ids })}
     />
   </Box>
 );

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -409,6 +409,7 @@
     "addProducts": "Add",
     "consumedProducts": "Consumed Products",
     "noProducts": "There are no products added yet...",
+    "selectProducts": "Select Products",
     "searchProduct": "Search for a product...",
     "noAvailableProducts": "No products available to add",
     "noImage": "No Image",
@@ -1133,6 +1134,7 @@
     "createPagesTooltip": "The bot will create website pages and send the link",
     "createDocuments": "Create Documents",
     "createDocumentsTooltip": "The bot will create documents",
+    "sell_products": "Sell Products",
     "emptyTitle":"You don't have chatbots",
     "emptyDesc":"Create your first chatbot.",
     "response": {

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -415,6 +415,7 @@
     "addProducts": "Adicionar",
     "consumedProducts": "Produtos Consumidos",
     "noProducts": "Ainda não há produtos adicionados...",
+    "selectProducts": "Selecionar Produtos",
     "searchProduct": "Buscar por um produto...",
     "noAvailableProducts": "Nenhum produto disponível para adicionar",
     "noImage": "Sem Imagem",
@@ -1140,6 +1141,7 @@
     "createPagesTooltip": "O bot criará páginas de site e enviará o link",
     "createDocuments": "Criar Documentos",
     "createDocumentsTooltip": "O Bot criará documentos",
+    "sell_products": "Vender Produtos",
     "emptyTitle":"Você não tem nenhum chatbot",
     "emptyDesc":"Crie seu primeiro chatbot.",
     "response": {


### PR DESCRIPTION
## Summary
- allow selecting products when creating chatbots
- add new 'sell products' option
- localize translations for new options

## Testing
- `npm test --silent --maxWorkers=2` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687530b3e53c8321b669de005db0a6d5