### PR TITLE
Change chatbot product selection payload

### DIFF
--- a/src/components/marketing/chatbot/ProductsSelectModal.tsx
+++ b/src/components/marketing/chatbot/ProductsSelectModal.tsx
@@ -8,7 +8,6 @@ import {
   Checkbox,
   Box,
   Grid,
-  Avatar,
   Typography,
   Paper,
   useTheme,
@@ -29,6 +28,7 @@ interface Product {
   id: string;
   name: string;
   description: string;
+  price?: number;
   images?: string[];
   instruction?: string;
 }
@@ -37,8 +37,8 @@ interface ProductsSelectModalProps {
   open: boolean;
   onClose: () => void;
   companyId: string;
-  selected: string[];
-  onChange: (ids: string[]) => void;
+  selected: Product[];
+  onChange: (products: Product[]) => void;
 }
 
 const ProductsSelectModal: React.FC<ProductsSelectModalProps> = ({
@@ -61,11 +61,10 @@ const ProductsSelectModal: React.FC<ProductsSelectModalProps> = ({
     }
   }, [open, companyId]);
 
-  const handleToggle = (id: string) => {
+  const handleToggle = (product: Product) => {
+    const exists = selected.some((p) => p.id === product.id);
     onChange(
-      selected.includes(id)
-        ? selected.filter((p) => p !== id)
-        : [...selected, id]
+      exists ? selected.filter((p) => p.id !== product.id) : [...selected, product]
     );
   };
 
@@ -117,12 +116,12 @@ const ProductsSelectModal: React.FC<ProductsSelectModalProps> = ({
         ) : (
           <Grid container spacing={2} sx={{ p: 2 }}>
             {products.map((product) => {
-              const isSelected = selected.includes(product.id);
+              const isSelected = selected.some(p => p.id === product.id);
               return (
                 <Grid item xs={12} sm={6} md={4} key={product.id}>
                   <Paper
                     elevation={isSelected ? 6 : 1}
-                    onClick={() => handleToggle(product.id)}
+                    onClick={() => handleToggle(product)}
                     sx={{
                       cursor: 'pointer',
                       borderRadius: 2,

--- a/src/components/marketing/chatbot/index.tsx
+++ b/src/components/marketing/chatbot/index.tsx
@@ -43,6 +43,13 @@ import { IoIosArrowBack } from 'react-icons/io';
 import { ChartGanttIcon, LockIcon, PlusCircle, PlusCircleIcon } from 'lucide-react';
 import { PlusOutlined } from '@ant-design/icons';
 
+interface Product {
+  id: string;
+  name: string;
+  description: string;
+  price?: number;
+}
+
 const initialBotConfig = {
   name: '',
   instruction: '',
@@ -55,7 +62,7 @@ const initialBotConfig = {
   welcomeMessage: '',
   pdfFiles: [],
   profileImage: null,
-  selectedProducts: [] as string[]
+  selectedProducts: [] as Product[]
 };
 
 export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: string) => void }> = ({ activeCompany, setModule }) => {
@@ -159,7 +166,12 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
       formData.append('createImages', botConfig.createImages);
       formData.append('createDocuments', botConfig.createDocuments);
       formData.append('sellProducts', botConfig.sellProducts);
-      formData.append('products', JSON.stringify(botConfig.selectedProducts));
+      const payloadProducts = botConfig.selectedProducts.map(p => ({
+        name: p.name,
+        description: p.description,
+        price: p.price
+      }));
+      formData.append('products', JSON.stringify(payloadProducts));
       formData.append('createPages', botConfig.createPages);
 
       if (botConfig.profileImage) {
@@ -226,7 +238,12 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
       formData.append('createImages', botConfig.createImages);
       formData.append('createDocuments', botConfig.createDocuments);
       formData.append('sellProducts', botConfig.sellProducts);
-      formData.append('products', JSON.stringify(botConfig.selectedProducts));
+      const payloadProducts = botConfig.selectedProducts.map(p => ({
+        name: p.name,
+        description: p.description,
+        price: p.price
+      }));
+      formData.append('products', JSON.stringify(payloadProducts));
       formData.append('createPages', botConfig.createPages);
 
       if (typeof botConfig.profileImage === 'string' && botConfig.profileImage.startsWith('http')) {
@@ -746,7 +763,7 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
         onClose={() => setProductsModalOpen(false)}
         companyId={activeCompany}
         selected={botConfig.selectedProducts}
-        onChange={(ids) => setBotConfig({ ...botConfig, selectedProducts: ids })}
+        onChange={(products) => setBotConfig({ ...botConfig, selectedProducts: products })}
       />
       </>
     );
@@ -1074,7 +1091,7 @@ return (
       onClose={() => setProductsModalOpen(false)}
       companyId={activeCompany}
       selected={botConfig.selectedProducts}
-      onChange={(ids) => setBotConfig({ ...botConfig, selectedProducts: ids })}
+      onChange={(products) => setBotConfig({ ...botConfig, selectedProducts: products })}
     />
   </Box>
 );


### PR DESCRIPTION
## Summary
- update product modal to return objects instead of IDs
- send name, description and price when creating or updating chatbots

## Testing
- `npm install --silent` *(fails: react-scripts not found)*
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764e21c77483219b44699b7bda18f8