### PR TITLE
Fix preselected chatbot products

### DIFF
--- a/src/components/marketing/chatbot/index.tsx
+++ b/src/components/marketing/chatbot/index.tsx
@@ -207,10 +207,12 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
       captureLeads: bot.captureLeads,
       createImages: bot.createImages,
       createDocuments: bot.createDocuments,
-      sellProducts: bot.sellProducts,
+      sellProducts: !!bot.sellProducts,
       createPages: bot.createPages,
       profileImage: bot.profileImage || null,
-      selectedProducts: bot.products || []
+      selectedProducts: bot.chatbotProducts
+        ? bot.chatbotProducts.map((cp) => cp.product)
+        : []
     });
     setCreatingBot(true);
   };


### PR DESCRIPTION
## Summary
- ensure chatbot update form uses `chatbotProducts` when editing

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876774fa5b08321907d87dd83151bf1