### PR TITLE
Add modal editor for chatbot instructions

### DIFF
--- a/src/components/marketing/chatbot/InstructionModal.tsx
+++ b/src/components/marketing/chatbot/InstructionModal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Dialog, DialogTitle, DialogContent, IconButton, TextField, Box } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+interface InstructionModalProps {
+  open: boolean;
+  onClose: () => void;
+  instruction: string;
+  onChange: (value: string) => void;
+}
+
+const InstructionModal: React.FC<InstructionModalProps> = ({ open, onClose, instruction, onChange }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', pr: 1 }}>
+        <span>{t('chatbot.instructions')}</span>
+        <IconButton onClick={onClose} sx={{ color: 'inherit' }}>
+          <Box component="span" fontSize="1.5rem">&times;</Box>
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <TextField
+          multiline
+          fullWidth
+          minRows={8}
+          name="instruction"
+          value={instruction}
+          onChange={(e) => onChange(e.target.value)}
+          variant="outlined"
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default InstructionModal;

--- a/src/components/marketing/chatbot/index.tsx
+++ b/src/components/marketing/chatbot/index.tsx
@@ -33,10 +33,12 @@ import {
   Upload as UploadIcon,
   PictureAsPdf as PdfIcon,
   WhatsApp,
-  History as HistoryIcon
+  History as HistoryIcon,
+  OpenInFull
 } from '@mui/icons-material';
 import ChatHistoryModal from './ChatHistoryModal.tsx';
 import ProductsSelectModal from './ProductsSelectModal.tsx';
+import InstructionModal from './InstructionModal.tsx';
 import ChatbotService from '../../../services/chatbot.service.ts';
 import { useNavigate } from 'react-router-dom';
 import { IoIosArrowBack } from 'react-icons/io';
@@ -82,6 +84,7 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
   const [historyBotId, setHistoryBotId] = useState<string | null>(null);
   const [historyBotSlug, setHistoryBotSlug] = useState<string | null>(null);
   const [productsModalOpen, setProductsModalOpen] = useState(false);
+  const [instructionModalOpen, setInstructionModalOpen] = useState(false);
   const navigate = useNavigate();
 
   const handleInputChange = (e) => {
@@ -381,21 +384,32 @@ export const ChatbotManager: React.FC<{ activeCompany: any, setModule: (module: 
                       }}
                     />
 
-                    <TextField
-                      fullWidth
-                      margin="normal"
-                      label={t('chatbot.instructions')}
-                      name="instruction"
-                      value={botConfig.instruction}
-                      onChange={handleInputChange}
-                      multiline
-                      rows={4}
-                      variant="outlined"
-                      placeholder={t('chatbot.instructionsPlaceholder')}
-                      InputProps={{
-                        sx: { borderRadius: 3 }
-                      }}
-                    />
+                    <Box sx={{ position: 'relative' }}>
+                      <TextField
+                        fullWidth
+                        margin="normal"
+                        label={t('chatbot.instructions')}
+                        name="instruction"
+                        value={botConfig.instruction}
+                        onChange={handleInputChange}
+                        multiline
+                        rows={4}
+                        variant="outlined"
+                        placeholder={t('chatbot.instructionsPlaceholder')}
+                        InputProps={{
+                          sx: { borderRadius: 3 }
+                        }}
+                      />
+                      <Tooltip title={t('chatbot.editInstruction')} arrow>
+                        <IconButton
+                          size="small"
+                          onClick={() => setInstructionModalOpen(true)}
+                          sx={{ position: 'absolute', bottom: 8, right: 8 }}
+                        >
+                          <OpenInFull fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </Box>
 
                     <TextField
                       fullWidth
@@ -1084,6 +1098,12 @@ return (
         ))}
       </Grid>
     )}
+    <InstructionModal
+      open={instructionModalOpen}
+      onClose={() => setInstructionModalOpen(false)}
+      instruction={botConfig.instruction}
+      onChange={(value) => setBotConfig({ ...botConfig, instruction: value })}
+    />
     <ChatHistoryModal
       open={historyOpen}
       onClose={handleCloseHistory}

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -1138,6 +1138,7 @@
     "createDocumentsTooltip": "The bot will create documents",
     "sellProducts": "Sell Products",
     "sellProductsTooltips": "The chatbot will create payment links and sell products",
+    "editInstruction": "Edit instruction",
     "emptyTitle":"You don't have chatbots",
     "emptyDesc":"Create your first chatbot.",
     "response": {

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -1145,6 +1145,7 @@
     "createDocumentsTooltip": "O Bot criará documentos",
     "sellProducts": "Vender Produtos",
     "sellProductsTooltips": "O chatbot irá criar links de pagamentos e vender produtos",
+    "editInstruction": "Editar instrução",
     "emptyTitle":"Você não tem nenhum chatbot",
     "emptyDesc":"Crie seu primeiro chatbot.",
     "response": {


### PR DESCRIPTION
## Summary
- add `InstructionModal` component
- overlay button for expanding instructions field
- sync edits between modal and main input
- add translation strings for editing instruction

## Testing
- `CI=true npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_687946e66e108321bba7917345f89f10