### PR TITLE
Add missing checkout i18n texts

### DIFF
--- a/src/data/en.json
+++ b/src/data/en.json
@@ -74,7 +74,19 @@
     "elite_plan": "Elite Plan",
     "pro_plan": "Pro Plan",
     "elite_price": "$10/month",
-    "pro_price": "$39/month"
+    "pro_price": "$39/month",
+    "createTitle": "Create Checkout",
+    "productsTitle": "Select Products",
+    "publicTitle": "Public Checkout",
+    "publicDescription": "Any customer with the link can make a purchase.",
+    "customerInfo": "Customer Information",
+    "customerName": "Customer Name",
+    "customerEmail": "Customer Email",
+    "createButton": "Create Checkout",
+    "selectProductsError": "Please select at least one product",
+    "customerInfoError": "Customer name and email are required",
+    "createdSuccess": "Checkout created successfully!",
+    "createError": "Error creating checkout"
   },
   "payment": {
     "success": "Payment successful!",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -74,7 +74,19 @@
     "elite_plan": "Plano Elite",
     "pro_plan": "Plano Pro",
     "elite_price": "R$29.90/mês",
-    "pro_price": "R$49.90/mês"
+    "pro_price": "R$49.90/mês",
+    "createTitle": "Criar Checkout",
+    "productsTitle": "Selecione os Produtos",
+    "publicTitle": "Checkout Público",
+    "publicDescription": "Qualquer cliente com o link poderá comprar.",
+    "customerInfo": "Informações do Cliente",
+    "customerName": "Nome do Cliente",
+    "customerEmail": "Email do Cliente",
+    "createButton": "Criar Checkout",
+    "selectProductsError": "Selecione ao menos um produto",
+    "customerInfoError": "Nome e email do cliente são obrigatórios",
+    "createdSuccess": "Checkout criado com sucesso!",
+    "createError": "Erro ao criar checkout"
   },
   "payment": {
     "success": "Pagamento realizado com sucesso!",


### PR DESCRIPTION
## Summary
- add translation keys for create checkout component

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module '@testing-library/react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687aa445394c8321af21ff2bd4e3da1d