### PR TITLE
Add checkout payment link

### DIFF
--- a/src/components/marketing/sales-pages/index.tsx
+++ b/src/components/marketing/sales-pages/index.tsx
@@ -87,6 +87,8 @@ interface Payment {
   paymentMethod: string;
   currency: string;
   status: string;
+  link?: string;
+  publicCheckout?: boolean;
   productId?: string;
   companyId?: string;
   customerId?: string;
@@ -476,31 +478,42 @@ const PaymentCard: React.FC<{ payment: Payment }> = ({ payment }) => {
         flexDirection: 'column'
       }}>
         <CardContent sx={{ flexGrow: 1 }}>
-          <Typography
-            variant="h5"
-            sx={{
-              fontWeight: 'bold',
-              mb: 1,
-              color: 'text.primary'
-            }}
-          >
-            {payment.description}
-          </Typography>
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Typography
+              variant="h5"
+              sx={{
+                fontWeight: 'bold',
+                mb: 1,
+                color: 'text.primary'
+              }}
+            >
+              {payment.description}
+            </Typography>
+            {payment.link && (
+              <ExternalLink
+                size={18}
+                style={{ cursor: 'pointer' }}
+                onClick={() => window.open(payment.link as string, '_blank')}
+              />
+            )}
+          </Box>
 
-          <Typography
-            variant="body2"
-            sx={{
-              color: payment.status === 'paid' ? 'success.main' : 'warning.main',
-              mb: 1.5,
-              display: 'inline-block',
-              px: 1,
-              py: 0.5,
-              bgcolor: payment.status === 'paid' ? 'rgba(76, 175, 80, 0.1)' : 'rgba(255, 152, 0, 0.1)',
-              borderRadius: 1
-            }}
-          >
-            {payment.status === 'paid' ? 'Paid' : 'Pending'}
-          </Typography>
+          {!payment.publicCheckout && (
+            <Typography
+              variant="body2"
+              sx={{
+                color: payment.status === 'paid' ? 'success.main' : 'warning.main',
+                mb: 1.5,
+                display: 'inline-block',
+                px: 1,
+                py: 0.5,
+                bgcolor: payment.status === 'paid' ? 'rgba(76, 175, 80, 0.1)' : 'rgba(255, 152, 0, 0.1)',
+                borderRadius: 1
+              }}
+            >
+              {payment.status === 'paid' ? 'Paid' : 'Pending'}
+            </Typography>
+          )}
 
           <Typography
             variant="h6"

--- a/src/components/marketing/sales-pages/mobile/index.tsx
+++ b/src/components/marketing/sales-pages/mobile/index.tsx
@@ -28,7 +28,7 @@ import {
   useTheme,
   alpha
 } from "@mui/material";
-import { AlertCircle, Check, CheckCircle, Clock, PlusCircle, ArrowLeft } from "lucide-react";
+import { AlertCircle, Check, CheckCircle, Clock, PlusCircle, ArrowLeft, ExternalLink } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useSnackbar } from "notistack";
 import { AccessTime, ArrowBackIos, Close, FormatListBulletedOutlined, InsertDriveFileOutlined } from "@mui/icons-material";
@@ -86,6 +86,8 @@ interface Payment {
   paymentMethod: string;
   currency: string;
   status: string;
+  link?: string;
+  publicCheckout?: boolean;
   productId?: string;
   companyId?: string;
   customerId?: string;
@@ -709,12 +711,23 @@ const MobileCapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ 
               <Grid item xs={6} key={payment.id}>
                 <Card sx={{ borderRadius: '12px', boxShadow: '0 4px 12px rgba(0,0,0,0.05)' }}>
                   <CardContent sx={{ p: 2 }}>
-                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-                      {payment.description}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {t('payments.status')}: {payment.status}
-                    </Typography>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                        {payment.description}
+                      </Typography>
+                      {payment.link && (
+                        <ExternalLink
+                          size={16}
+                          style={{ cursor: 'pointer' }}
+                          onClick={() => window.open(payment.link as string, '_blank')}
+                        />
+                      )}
+                    </Box>
+                    {!payment.publicCheckout && (
+                      <Typography variant="body2" color="text.secondary">
+                        {t('payments.status')}: {payment.status}
+                      </Typography>
+                    )}
                     <Typography variant="body2" color="text.secondary">
                       {t('payments.currency')}: {payment.currency}
                     </Typography>


### PR DESCRIPTION
## Summary
- show external link for checkout payments
- hide payment status when checkout is public

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687addd2d6608321b722bd5ff1c49040