### PR TITLE
Add deletion option for payments

### DIFF
--- a/src/data/en.json
+++ b/src/data/en.json
@@ -86,7 +86,9 @@
     "selectProductsError": "Please select at least one product",
     "customerInfoError": "Customer name and email are required",
     "createdSuccess": "Checkout created successfully!",
-    "createError": "Error creating checkout"
+    "createError": "Error creating checkout",
+    "confirmDeletePaymentTitle": "Confirm deletion",
+    "confirmDeletePaymentMessage": "Are you sure you want to delete this payment?"
   },
   "payment": {
     "success": "Payment successful!",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -86,7 +86,9 @@
     "selectProductsError": "Selecione ao menos um produto",
     "customerInfoError": "Nome e email do cliente são obrigatórios",
     "createdSuccess": "Checkout criado com sucesso!",
-    "createError": "Erro ao criar checkout"
+    "createError": "Erro ao criar checkout",
+    "confirmDeletePaymentTitle": "Confirmar exclusão",
+    "confirmDeletePaymentMessage": "Tem certeza que deseja excluir este pagamento?"
   },
   "payment": {
     "success": "Pagamento realizado com sucesso!",

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -13,5 +13,8 @@ class PaymentService {
     static create(data: any) {
                 return http.post(`/payment/create`, data);
         }
+    static delete(id: string) {
+                return http.delete(`/payment/${id}`);
+        }
 }
 export default PaymentService;


### PR DESCRIPTION
## Summary
- add delete endpoint handler in `payment.service`
- translate delete confirmation labels
- show trash icon and confirm dialog on payment cards (desktop & mobile)

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba6e0f9e083219872aa84b7c4c13e