### PR TITLE
Add payment name and description fields

### DIFF
--- a/src/components/marketing/create-checkout/index.tsx
+++ b/src/components/marketing/create-checkout/index.tsx
@@ -41,6 +41,8 @@ const CreateCheckoutForm: React.FC<{ activeCompany: string; setModule: any }> = 
   const [publicCheckout, setPublicCheckout] = useState(true);
   const [customerName, setCustomerName] = useState('');
   const [customerEmail, setCustomerEmail] = useState('');
+  const [paymentName, setPaymentName] = useState('');
+  const [paymentDescription, setPaymentDescription] = useState('');
 
   useEffect(() => {
     if (activeCompany) {
@@ -63,6 +65,8 @@ const CreateCheckoutForm: React.FC<{ activeCompany: string; setModule: any }> = 
       userId: 'userData?._id',
       companyId: activeCompany,
       publicCheckout: publicCheckout,
+      paymentName,
+      paymentDescription,
     };
 
     if (!publicCheckout) {
@@ -100,6 +104,36 @@ const CreateCheckoutForm: React.FC<{ activeCompany: string; setModule: any }> = 
             </Typography>
           </Box>
       </Box>
+      <Paper elevation={0} sx={{
+        p: 3,
+        mb: 4,
+        borderRadius: 3,
+        border: `1px solid ${theme.palette.divider}`,
+        backgroundColor: theme.palette.background.paper
+      }}>
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label={t('checkout.paymentName')}
+              value={paymentName}
+              onChange={(e) => setPaymentName(e.target.value)}
+              variant="outlined"
+              size="small"
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <TextField
+              fullWidth
+              label={t('checkout.paymentDescription')}
+              value={paymentDescription}
+              onChange={(e) => setPaymentDescription(e.target.value)}
+              variant="outlined"
+              size="small"
+            />
+          </Grid>
+        </Grid>
+      </Paper>
       <Paper elevation={0} sx={{
         p: 3,
         mb: 4,

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -76,6 +76,8 @@
     "elite_price": "$10/month",
     "pro_price": "$39/month",
     "createTitle": "Create Checkout",
+    "paymentName": "Name",
+    "paymentDescription": "Description",
     "productsTitle": "Select Products",
     "publicTitle": "Public Checkout",
     "publicDescription": "Any customer with the link can make a purchase.",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -76,6 +76,8 @@
     "elite_price": "R$29.90/mês",
     "pro_price": "R$49.90/mês",
     "createTitle": "Criar Checkout",
+    "paymentName": "Nome",
+    "paymentDescription": "Descrição",
     "productsTitle": "Selecione os Produtos",
     "publicTitle": "Checkout Público",
     "publicDescription": "Qualquer cliente com o link poderá comprar.",


### PR DESCRIPTION
## Summary
- add Payment Name and Payment Description translations
- allow setting name and description when creating a checkout

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bab226d888321a5eec16f3064a778