### PR TITLE
Implement WhatsApp linking for chatbots

### DIFF
--- a/src/data/en.json
+++ b/src/data/en.json
@@ -1130,7 +1130,7 @@
     "profileImageHint": "Click to upload an image",
     "knowledgeBase": "Knowledge Base",
     "uploadPDFs": "Upload PDFs",
-    "connectWhatsappHint": "You can use this chatbot in WhatsApp",
+    "connectWhatsappHint": "This chatbot will be linked to WhatsApp. Only one chatbot can be connected per company.",
     "connectWhatsapp": "Connect WhatsApp",
     "connectedWhatsapp": "WhatsApp Connected",
     "generateTemplates": "Generate templates automatically",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -1138,7 +1138,7 @@
     "knowledgeBase": "Base de Conhecimento",
     "uploadPDFs": "Enviar PDFs",
     "generateTemplates": "Gerar templates automaticamente",
-    "connectWhatsappHint": "Você pode usar este chatbot no WhatsApp",
+    "connectWhatsappHint": "Este chatbot será vinculado ao WhatsApp. Apenas um chatbot pode ser conectado por empresa.",
     "connectWhatsapp": "Conectar WhatsApp",
     "connectedWhatsapp": "WhatsApp Conectado",
     "generateTemplatesTooltip": "O bot irá sugerir modelos de resposta com base nas interações",


### PR DESCRIPTION
## Summary
- add WhatsApp integration modal when linking a chatbot
- send `linkToWhatsapp` flag on create and update
- update tooltip translations about WhatsApp linking

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e03516148321addc5aeacf2e5cfb