### PR TITLE
Implement deletion confirmation for chatbot threads

### DIFF
--- a/src/components/marketing/chatbot/ChatHistoryModal.tsx
+++ b/src/components/marketing/chatbot/ChatHistoryModal.tsx
@@ -33,6 +33,7 @@ const ChatHistoryModal: React.FC<ChatHistoryModalProps> = ({ open, onClose, botI
   const [loading, setLoading] = useState(false);
   const [threads, setThreads] = useState<any[]>([]);
   const [selected, setSelected] = useState<any | null>(null);
+  const [threadToDelete, setThreadToDelete] = useState<string | null>(null);
 
   const handleDeleteThread = async (threadId: string) => {
     try {
@@ -111,7 +112,7 @@ const renderThreadsList = () => {
                 size="small"
                 onClick={(e) => {
                   e.stopPropagation();
-                  handleDeleteThread(thread.threadId);
+                  setThreadToDelete(thread.threadId);
                 }}
                 sx={{ position: 'absolute', bottom: 6, right: 8 }}
               >
@@ -231,6 +232,7 @@ const renderThreadsList = () => {
   );
 
   return (
+    <>
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>
         {selected ? `${t('chatbot.conversation')} ${threads.indexOf(selected) + 1}` : t('chatbot.historyTitle')}
@@ -261,6 +263,17 @@ const renderThreadsList = () => {
         </Button>
       </DialogActions>
     </Dialog>
+    <Dialog open={Boolean(threadToDelete)} onClose={() => setThreadToDelete(null)} maxWidth="xs" fullWidth>
+      <DialogTitle>{t('chatbot.confirmDeleteThreadTitle')}</DialogTitle>
+      <DialogContent dividers>
+        <Typography>{t('chatbot.confirmDeleteThreadMessage')}</Typography>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => setThreadToDelete(null)}>{t('cancel')}</Button>
+        <Button color="error" variant="contained" onClick={() => threadToDelete && (handleDeleteThread(threadToDelete), setThreadToDelete(null))}>{t('delete')}</Button>
+      </DialogActions>
+    </Dialog>
+    </>
   );
 };
 

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -1148,6 +1148,8 @@
     "noHistory": "No conversation history",
     "conversation": "Conversation",
     "openConversation": "Open Conversation",
+    "confirmDeleteThreadTitle": "Confirm deletion",
+    "confirmDeleteThreadMessage": "Are you sure you want to delete this conversation?",
     "captureLeads": "Capture leads",
     "captureLeadsTooltip": "The bot will capture leads automatically",
     "createImages": "Create Images",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -1155,6 +1155,8 @@
     "noHistory": "Nenhum histórico de conversa",
     "conversation": "Conversa",
     "openConversation": "Abrir Conversa",
+    "confirmDeleteThreadTitle": "Confirmar exclusão",
+    "confirmDeleteThreadMessage": "Tem certeza que deseja excluir esta conversa?",
     "captureLeads": "Capturar leads",
     "captureLeadsTooltip": "O Bot capturará leads automaticamente",
     "createImages": "Criar Imagens",


### PR DESCRIPTION
## Summary
- show confirmation dialog before removing a conversation thread
- add i18n labels for thread deletion confirmation

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837adfe05483219d0557f7ee26da8b