### PR TITLE
Use API_URL env

### DIFF
--- a/src/components/marketing/capture-pages/index.tsx
+++ b/src/components/marketing/capture-pages/index.tsx
@@ -29,6 +29,7 @@ import LandingPageService from "../../../services/landing-page.service.ts";
 import LeadsService from "../../../services/leads.service.ts";
 import { useSnackbar } from "notistack";
 import ProgressService from "../../../services/progress.service.ts";
+import { API_URL } from "../../../config/api.ts";
 
 // Importações para o Chart.js
 import { Bar } from "react-chartjs-2";
@@ -850,7 +851,7 @@ const TemplateDialog: React.FC<{
           disabled={newPage.title === "" || (mode === "choose" && !selectedTemplate) || generating}
           onClick={async () => {
             if (mode === "choose") {
-              setPreviewUrl(`https://roktune.duckdns.org/landing-pages/preview?type=${selectedTemplate.type}&companyId=${activeCompany}&title=${newPage.title}`);
+              setPreviewUrl(`${API_URL}/landing-pages/preview?type=${selectedTemplate.type}&companyId=${activeCompany}&title=${newPage.title}`);
             } else {
               const orderedSections = sections.filter((s) => s.trim() !== "");
               setGenerating(true);
@@ -864,7 +865,7 @@ const TemplateDialog: React.FC<{
               }).then((res)=>{
                 setGenerating(false);
                 setProgress({});
-                setPreviewUrl(`https://roktune.duckdns.org/landing-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${newPage.title}`);
+                setPreviewUrl(`${API_URL}/landing-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${newPage.title}`);
               })
               .catch((err)=>{console.log(err)});
 
@@ -987,7 +988,7 @@ const EditDialog: React.FC<{
       <DialogContent>
         {landingPage ? (
           <iframe
-            src={`https://roktune.duckdns.org/landing-pages/edit/${landingPage.id}`}
+            src={`${API_URL}/landing-pages/edit/${landingPage.id}`}
             width="100%"
             height="500px"
             style={{ border: "none" }}
@@ -1107,7 +1108,7 @@ const CapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ active
   };
 
   const handleViewWebsite = (page: LandingPage) => {
-    window.open(`https://roktune.duckdns.org/landing-pages/page/${page.id}`, "_blank");
+    window.open(`${API_URL}/landing-pages/page/${page.id}`, "_blank");
   };
 
   const handleEditPage = (page: LandingPage) => {
@@ -1133,7 +1134,7 @@ const CapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ active
   };
 
   const handleViewFormWebsite = (form: FormLead) => {
-    window.open(`https://roktune.duckdns.org/leads/form?apiKey=${form.apiKey}`, "_blank");
+    window.open(`${API_URL}/leads/form?apiKey=${form.apiKey}`, "_blank");
   };
 
   const saveLandingPageAsActive = async () => {

--- a/src/components/marketing/capture-pages/mobile/index.tsx
+++ b/src/components/marketing/capture-pages/mobile/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { API_URL } from "../../../../config/api.ts";
 import {
   Card,
   CardContent,
@@ -228,7 +229,7 @@ const EditDialog: React.FC<{
       <DialogContent>
         {landingPage ? (
           <iframe
-            src={`https://roktune.duckdns.org/landing-pages/edit/${landingPage.id}`}
+            src={`${API_URL}/landing-pages/edit/${landingPage.id}`}
             width="100%"
             height={isMobile ? '100%' : '500px'}
             style={{ border: 'none' }}
@@ -332,11 +333,11 @@ const MobileCapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ 
   }, [generating]);
 
   const handleViewWebsite = (page: LandingPage) => {
-    window.open(`https://roktune.duckdns.org/landing-pages/page/${page.id}`, "_blank");
+    window.open(`${API_URL}/landing-pages/page/${page.id}`, "_blank");
   };
 
   const handleViewFormWebsite = (form: FormLead) => {
-    window.open(`https://roktune.duckdns.org/landing-pages//leads/form?apiKey=${form.apiKey}`, "_blank");
+    window.open(`${API_URL}/landing-pages//leads/form?apiKey=${form.apiKey}`, "_blank");
   };
 
   const handleEditPage = (page: LandingPage) => {
@@ -1207,7 +1208,7 @@ const MobileCapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ 
             });
 
             setPreviewUrl(
-              `https://roktune.duckdns.org/landing-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${encodeURIComponent(
+              `${API_URL}/landing-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${encodeURIComponent(
                 newPage.title
               )}`
             );
@@ -1222,7 +1223,7 @@ const MobileCapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ 
         } else {
           setOpenForm(false);
           setPreviewUrl(
-            `https://roktune.duckdns.org/landing-pages/preview?type=${selectedTemplate?.type}&companyId=${activeCompany}&title=${encodeURIComponent(
+            `${API_URL}/landing-pages/preview?type=${selectedTemplate?.type}&companyId=${activeCompany}&title=${encodeURIComponent(
               newPage.title
             )}`
           );

--- a/src/components/marketing/chatbot/ChatHistoryModal.tsx
+++ b/src/components/marketing/chatbot/ChatHistoryModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { API_URL } from '../../../config/api.ts';
 import {
   Dialog,
   DialogTitle,
@@ -129,7 +130,7 @@ const renderThreadsList = () => {
                 <Tooltip title={t('chatbot.openConversation')} arrow>
                   <IconButton
                     size="small"
-                    onClick={() => window.open(`https://roktune.duckdns.org/chatbot/s/${botSlug}?threadId=${thread.threadId}`, '_blank')}
+                    onClick={() => window.open(`${API_URL}/chatbot/s/${botSlug}?threadId=${thread.threadId}`, '_blank')}
                     sx={{ position: 'absolute', bottom: 6, right: 52 }}
                   >
                     <Launch fontSize="small" />

--- a/src/components/marketing/chatbot/index.tsx
+++ b/src/components/marketing/chatbot/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { API_URL } from '../../../config/api.ts';
 import {
   Box,
   Button,
@@ -1102,7 +1103,7 @@ return (
                   <HistoryIcon />
                 </Button>
                 <Button
-                  onClick={() => window.open(`https://roktune.duckdns.org/chatbot/s/${bot.slug}`, '_blank')}
+                  onClick={() => window.open(`${API_URL}/chatbot/s/${bot.slug}`, '_blank')}
                   size="small"
                   variant="outlined"
                   sx={{

--- a/src/components/marketing/form-preview/index.tsx
+++ b/src/components/marketing/form-preview/index.tsx
@@ -12,6 +12,7 @@ import {
 import { ArrowLeft } from "lucide-react";
 import LeadsService from "../../../services/leads.service.ts";
 import { useTranslation } from "react-i18next";
+import { API_URL } from "../../../config/api.ts";
 
 interface IField {
   name: string;
@@ -155,7 +156,7 @@ const LeadFormPreview: React.FC<LeadFormPreviewProps> = ({
 
   // When apiKey is available, set integration modal data
   useEffect(() => {
-    const directLink = `https://roktune.duckdns.org/leads/form?apiKey=${apiKey}`;
+    const directLink = `${API_URL}/leads/form?apiKey=${apiKey}`;
     const embedCode = `<iframe src="${directLink}" frameborder="0" width="100%" height="600"></iframe>`;
     setIntegrationData({ embedCode, directLink });
     if (apiKey) {

--- a/src/components/marketing/sales-pages/index.tsx
+++ b/src/components/marketing/sales-pages/index.tsx
@@ -33,6 +33,7 @@ import LeadsService from "../../../services/leads.service.ts";
 import PaymentService from "../../../services/payment.service.ts";
 import { useSnackbar } from "notistack";
 import ProgressService from "../../../services/progress.service.ts";
+import { API_URL } from "../../../config/api.ts";
 
 // Importações para o Chart.js
 import { Bar, Line } from "react-chartjs-2";
@@ -1013,7 +1014,7 @@ const TemplateDialog: React.FC<{
           disabled={newPage.title === "" || (mode === "choose" && !selectedTemplate) || generating}
           onClick={async () => {
             if (mode === "choose") {
-              setPreviewUrl(`https://roktune.duckdns.org/sales-pages/preview?type=${selectedTemplate.type}&companyId=${activeCompany}&title=${newPage.title}&salesPage=true`);
+              setPreviewUrl(`${API_URL}/sales-pages/preview?type=${selectedTemplate.type}&companyId=${activeCompany}&title=${newPage.title}&salesPage=true`);
             } else {
               const orderedSections = sections.filter((s) => s.trim() !== "");
               setGenerating(true);
@@ -1027,7 +1028,7 @@ const TemplateDialog: React.FC<{
               }).then((res)=>{
                 setGenerating(false);
                 setProgress({});
-                setPreviewUrl(`https://roktune.duckdns.org/sales-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${newPage.title}&salesPage=true`);
+                setPreviewUrl(`${API_URL}/sales-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${newPage.title}&salesPage=true`);
               })
               .catch((err)=>{console.log(err)});
 
@@ -1150,7 +1151,7 @@ const EditDialog: React.FC<{
       <DialogContent>
         {salesPage ? (
           <iframe
-            src={`https://roktune.duckdns.org/sales-pages/edit/${salesPage.id}`}
+            src={`${API_URL}/sales-pages/edit/${salesPage.id}`}
             width="100%"
             height="500px"
             style={{ border: "none" }}
@@ -1272,7 +1273,7 @@ const CapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ active
   };
 
   const handleViewWebsite = (page: SalesPage) => {
-    window.open(`https://roktune.duckdns.org/sales-pages/page/${page.id}`, "_blank");
+    window.open(`${API_URL}/sales-pages/page/${page.id}`, "_blank");
   };
 
   const handleEditPage = (page: SalesPage) => {
@@ -1298,7 +1299,7 @@ const CapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ active
   };
 
   const handleViewFormWebsite = (form: FormLead) => {
-    window.open(`https://roktune.duckdns.org/leads/form?apiKey=${form.apiKey}`, "_blank");
+    window.open(`${API_URL}/leads/form?apiKey=${form.apiKey}`, "_blank");
   };
 
   const confirmDeletePayment = async () => {

--- a/src/components/marketing/sales-pages/mobile/index.tsx
+++ b/src/components/marketing/sales-pages/mobile/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { API_URL } from "../../../../config/api.ts";
 import {
   Card,
   CardContent,
@@ -249,7 +250,7 @@ const EditDialog: React.FC<{
       <DialogContent>
         {landingPage ? (
           <iframe
-            src={`https://roktune.duckdns.org/sales-pages/edit/${landingPage.id}`}
+            src={`${API_URL}/sales-pages/edit/${landingPage.id}`}
             width="100%"
             height={isMobile ? '100%' : '500px'}
             style={{ border: 'none' }}
@@ -355,11 +356,11 @@ const MobileCapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ 
   }, [generating]);
 
   const handleViewWebsite = (page: SalesPage) => {
-    window.open(`https://roktune.duckdns.org/sales-pages/page/${page.id}`, "_blank");
+    window.open(`${API_URL}/sales-pages/page/${page.id}`, "_blank");
   };
 
   const handleViewFormWebsite = (form: FormLead) => {
-    window.open(`https://roktune.duckdns.org/sales-pages//leads/form?apiKey=${form.apiKey}`, "_blank");
+    window.open(`${API_URL}/sales-pages//leads/form?apiKey=${form.apiKey}`, "_blank");
   };
 
   const handleEditPage = (page: SalesPage) => {
@@ -1181,7 +1182,7 @@ const MobileCapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ 
             });
 
             setPreviewUrl(
-              `https://roktune.duckdns.org/sales-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${encodeURIComponent(
+              `${API_URL}/sales-pages/preview?type=${res.data}&companyId=${activeCompany}&title=${encodeURIComponent(
                 newPage.title
               )}`
             );
@@ -1196,7 +1197,7 @@ const MobileCapturePages: React.FC<{ activeCompany: any; setModule: any }> = ({ 
         } else {
           setOpenForm(false);
           setPreviewUrl(
-            `https://roktune.duckdns.org/sales-pages/preview?type=${selectedTemplate?.type}&companyId=${activeCompany}&title=${encodeURIComponent(
+            `${API_URL}/sales-pages/preview?type=${selectedTemplate?.type}&companyId=${activeCompany}&title=${encodeURIComponent(
               newPage.title
             )}`
           );

--- a/src/components/smart-tag/index.tsx
+++ b/src/components/smart-tag/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { API_URL } from '../../config/api.ts';
 import {
   Box,
   Typography,
@@ -69,7 +70,7 @@ const Tracking: React.FC<{ activeCompany: string, userData: any }> = ({ activeCo
   };
 
   const handleCopy = () => {
-    const scriptTag = `<script src="https://roktune.duckdns.org/integracao.js" data-api-key="${tagData.apiKey}"></script>`;
+    const scriptTag = `<script src="${API_URL}/integracao.js" data-api-key="${tagData.apiKey}"></script>`;
     navigator.clipboard.writeText(scriptTag);
     setCopySuccess(true);
   };
@@ -221,7 +222,7 @@ const Tracking: React.FC<{ activeCompany: string, userData: any }> = ({ activeCo
                       position: 'relative'
                     }}
                   >
-                    {`<script src="https://roktune.duckdns.org/integracao.js" data-api-key="${tagData.apiKey}"></script>`}
+                    {`<script src="${API_URL}/integracao.js" data-api-key="${tagData.apiKey}"></script>`}
                     <IconButton
                       onClick={handleCopy}
                       sx={{ position: 'absolute', top: 8, right: 8 }}

--- a/src/components/smart-tag/smart-tag-home/index.tsx
+++ b/src/components/smart-tag/smart-tag-home/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { API_URL } from '../../../config/api.ts';
 import {
   Box,
   Typography,
@@ -442,7 +443,7 @@ const TrackingHome: React.FC<{ activeCompany: string; userData: any; apiKey: str
                 position: 'relative',
               }}
             >
-              {`<script src="https://roktune.duckdns.org/integracao.js" data-api-key="${apiKey}"></script>`}
+              {`<script src="${API_URL}/integracao.js" data-api-key="${apiKey}"></script>`}
             </Box>
           </Paper>
         </Box>

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,1 @@
+export const API_URL = process.env.REACT_APP_API_URL || '';

--- a/src/services/http-business.ts
+++ b/src/services/http-business.ts
@@ -1,12 +1,10 @@
 /* eslint-disable no-param-reassign */
 import axios, { AxiosRequestConfig } from 'axios';
 import { getStorageValue } from '../hooks/useLocalStorage.ts';
-
-// https://roktune.duckdns.org/
-// process.env.REACT_APP_API_URL
+import { API_URL } from '../config/api.ts';
 
 const axiosInstance = axios.create({
-	baseURL: 'https://roktune.duckdns.org/',
+        baseURL: API_URL,
 	headers: {
 		'Content-type': 'application/json',
 		'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
## Summary
- centralize API URL in `API_URL` constant
- reference `API_URL` instead of direct backend URLs

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a169f5ed08321a8b7943f44f01eef