### PR TITLE
feat: add integrations module

### DIFF
--- a/src/components/integrations/index.tsx
+++ b/src/components/integrations/index.tsx
@@ -1,15 +1,33 @@
-import React, { useEffect, useState } from 'react';
+import React, { JSX, useEffect, useState } from 'react';
 import {
   Grid,
   Card,
   CardContent,
   Typography,
-  CardActions,
   Button,
   Avatar,
+  Box,
+  Chip,
+  Divider,
+  IconButton,
+  Tooltip,
+  LinearProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  useTheme,
+  useMediaQuery,
+  Menu,
+  MenuItem
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { FaFacebookF, FaInstagram, FaWhatsapp, FaLinkedinIn, FaTwitter, FaGoogle, FaYoutube, FaEnvelope } from 'react-icons/fa';
+import {
+  FaFacebookF, FaInstagram, FaWhatsapp, FaLinkedinIn,
+  FaTwitter, FaGoogle, FaYoutube, FaEnvelope,
+  FaCheck, FaTimes, FaPlug, FaUnlink, FaEllipsisV,
+  FaInfoCircle
+} from 'react-icons/fa';
 import FacebookService from '../../services/facebook.service.ts';
 import InstagramService from '../../services/instagram.service.ts';
 import WhatsappService from '../../services/whatsapp.service.ts';
@@ -18,6 +36,7 @@ import TwitterService from '../../services/twitter.service.ts';
 import YouTubeService from '../../services/youtube.service.ts';
 import EmailService from '../../services/email.service.ts';
 import http from '../../services/http-business.ts';
+import { motion } from 'framer-motion';
 
 type IntegrationConfig = {
   key: string;
@@ -34,7 +53,7 @@ const integrations: IntegrationConfig[] = [
     key: 'facebook',
     name: 'Facebook',
     color: '#1877F2',
-    icon: <FaFacebookF size={40} />,
+    icon: <FaFacebookF size={24} />,
     checkStatus: FacebookService.checkFacebookStatus,
     connect: (companyId) => FacebookService.getAuthLink(companyId),
     disconnect: (companyId) => http.delete(`/facebook/disconnect?companyId=${companyId}`),
@@ -43,7 +62,7 @@ const integrations: IntegrationConfig[] = [
     key: 'instagram',
     name: 'Instagram',
     color: '#E1306C',
-    icon: <FaInstagram size={40} />,
+    icon: <FaInstagram size={24} />,
     checkStatus: InstagramService.checkInstagramStatus,
     connect: (companyId) => InstagramService.getAuthLink(companyId),
     disconnect: (companyId) => http.delete(`/instagram/disconnect?companyId=${companyId}`),
@@ -52,7 +71,7 @@ const integrations: IntegrationConfig[] = [
     key: 'whatsapp',
     name: 'WhatsApp',
     color: '#25D366',
-    icon: <FaWhatsapp size={40} />,
+    icon: <FaWhatsapp size={24} />,
     checkStatus: WhatsappService.checkWhatsAppStatus,
     connect: (companyId) => WhatsappService.getQrCode(companyId),
     disconnect: (companyId) => http.delete(`/whatsapp/disconnect?companyId=${companyId}`),
@@ -61,7 +80,7 @@ const integrations: IntegrationConfig[] = [
     key: 'linkedin',
     name: 'LinkedIn',
     color: '#0A66C2',
-    icon: <FaLinkedinIn size={40} />,
+    icon: <FaLinkedinIn size={24} />,
     checkStatus: LinkedinService.checkLinkedinStatus,
     connect: (companyId) => LinkedinService.getAuthLink(companyId),
     disconnect: (companyId) => http.delete(`/linkedin/disconnect?companyId=${companyId}`),
@@ -70,7 +89,7 @@ const integrations: IntegrationConfig[] = [
     key: 'twitter',
     name: 'Twitter',
     color: '#1DA1F2',
-    icon: <FaTwitter size={40} />,
+    icon: <FaTwitter size={24} />,
     checkStatus: TwitterService.checkTwitterStatus,
     connect: (companyId) => TwitterService.getAuthLink(companyId),
     disconnect: (companyId) => http.delete(`/twitter/disconnect?companyId=${companyId}`),
@@ -79,7 +98,7 @@ const integrations: IntegrationConfig[] = [
     key: 'google',
     name: 'Google',
     color: '#4285F4',
-    icon: <FaGoogle size={40} />,
+    icon: <FaGoogle size={24} />,
     checkStatus: (companyId) => http.get(`/google/status?companyId=${companyId}`),
     connect: (companyId) => http.get(`/google/auth-link?companyId=${companyId}`),
     disconnect: (companyId) => http.delete(`/google/disconnect?companyId=${companyId}`),
@@ -88,7 +107,7 @@ const integrations: IntegrationConfig[] = [
     key: 'youtube',
     name: 'YouTube',
     color: '#FF0000',
-    icon: <FaYoutube size={40} />,
+    icon: <FaYoutube size={24} />,
     checkStatus: YouTubeService.checkYoutubeStatus,
     connect: (companyId) => YouTubeService.getAuthLink(companyId),
     disconnect: (companyId) => http.delete(`/youtube/disconnect?companyId=${companyId}`),
@@ -97,111 +116,368 @@ const integrations: IntegrationConfig[] = [
     key: 'email',
     name: 'Email',
     color: '#555555',
-    icon: <FaEnvelope size={40} />,
+    icon: <FaEnvelope size={24} />,
     checkStatus: (companyId) => EmailService.getAccount(companyId),
     connect: (companyId) => EmailService.createAccount({ companyId }),
     disconnect: (companyId) => http.delete(`/email/disconnect?companyId=${companyId}`),
   },
 ];
 
+const IntegrationCard = ({
+  integration,
+  isConnected,
+  handleConnect,
+  handleDisconnect,
+  openMenu,
+  t
+}) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  return (
+    <motion.div
+      whileHover={{ y: -5 }}
+      transition={{ duration: 0.2 }}
+    >
+      <Card
+        sx={{
+          minWidth: 275,
+          borderRadius: 3,
+          boxShadow: '0 4px 20px rgba(0,0,0,0.05)',
+          background: 'linear-gradient(to bottom, #ffffff, #f8f9ff)',
+          border: '1px solid #eef0f8',
+          transition: 'all 0.3s ease',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          '&:hover': {
+            boxShadow: '0 8px 25px rgba(87, 138, 205, 0.15)',
+            transform: 'translateY(-3px)',
+          },
+        }}
+      >
+        <CardContent sx={{ pt: 3, pb: 2, flexGrow: 1, ml:4}}>
+          <Box display="flex" justifyContent="space-between" alignItems="center">
+            <Box display="flex" alignItems="center">
+              <Avatar
+                sx={{
+                  width: 50,
+                  height: 50,
+                  mr: 2,
+                  bgcolor: integration.color,
+                  color: 'white',
+                  boxShadow: `0 4px 12px ${integration.color}40`,
+                }}
+              >
+                {integration.icon}
+              </Avatar>
+              <Box>
+                <Typography variant="h6" fontWeight={600} color="text.primary">
+                  {integration.name}
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
+        </CardContent>
+
+        <Box sx={{ px: 0, pb: 0 }}>
+{isConnected ? (
+  <Button
+    fullWidth
+    variant="text"
+    startIcon={<FaUnlink size={14} />}
+    onClick={() => handleDisconnect(integration)}
+    sx={{
+      py: 1,
+      fontWeight: 500,
+      color: '#f44336',
+      '&:hover': {
+        backgroundColor: 'rgba(244, 67, 54, 0.04)',
+      },
+      '& .MuiButton-startIcon': {
+        marginRight: '6px',
+        transition: 'transform 0.2s ease'
+      },
+      '&:hover .MuiButton-startIcon': {
+        transform: 'rotate(-15deg)'
+      },
+      position: 'relative',
+      overflow: 'hidden',
+      transition: 'all 0.3s ease'
+    }}
+  >
+    {t('integration.disconnect')}
+  </Button>
+) : (
+  <Button
+    fullWidth
+    variant="text"
+    startIcon={<FaPlug size={14} />}
+    onClick={() => handleConnect(integration)}
+    sx={{
+      py: 1,
+      fontWeight: 500,
+      color: '#578acd',
+      '&:hover': {
+        backgroundColor: 'rgba(87, 138, 205, 0.04)',
+        color: '#3a6fb5',
+      },
+      '& .MuiButton-startIcon': {
+        marginRight: '6px',
+        transition: 'transform 0.2s ease'
+      },
+      '&:hover .MuiButton-startIcon': {
+        transform: 'rotate(90deg)'
+      },
+      position: 'relative',
+      overflow: 'hidden',
+      transition: 'all 0.3s ease'
+    }}
+  >
+    {t('integration.connect')}
+  </Button>
+)}
+        </Box>
+      </Card>
+    </motion.div>
+  );
+};
+
 const Integrations: React.FC<{ activeCompany: string }> = ({ activeCompany }) => {
   const { t } = useTranslation();
   const [status, setStatus] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
+  const [selectedIntegration, setSelectedIntegration] = useState<IntegrationConfig | null>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [dialogType, setDialogType] = useState<'connect' | 'disconnect' | 'info'>('info');
+  const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'disconnecting' | 'idle'>('idle');
 
   useEffect(() => {
     if (!activeCompany) return;
-    integrations.forEach(async (integration) => {
-      try {
-        const result = await integration.checkStatus(activeCompany);
-        setStatus((prev) => ({ ...prev, [integration.key]: !!result }));
-      } catch (err) {
-        setStatus((prev) => ({ ...prev, [integration.key]: false }));
-      }
-    });
+
+    const fetchStatus = async () => {
+      setLoading(true);
+      const statuses: Record<string, boolean> = {};
+
+      await Promise.all(integrations.map(async (integration) => {
+        try {
+          const result = await integration.checkStatus(activeCompany);
+          statuses[integration.key] = !!result;
+        } catch (err) {
+          statuses[integration.key] = false;
+        }
+      }));
+
+      setStatus(statuses);
+      setLoading(false);
+    };
+
+    fetchStatus();
   }, [activeCompany]);
 
   const handleConnect = async (integration: IntegrationConfig) => {
-    const response = await integration.connect(activeCompany);
-    if (response?.data) {
-      window.location.href = response.data;
+    setConnectionStatus('connecting');
+    try {
+      const response = await integration.connect(activeCompany);
+      if (response?.data) {
+        window.location.href = response.data;
+      }
+    } catch (error) {
+      console.error("Connection failed:", error);
+    } finally {
+      setConnectionStatus('idle');
+      handleCloseDialog();
     }
   };
 
   const handleDisconnect = async (integration: IntegrationConfig) => {
-    await integration.disconnect(activeCompany);
-    setStatus((prev) => ({ ...prev, [integration.key]: false }));
+    setConnectionStatus('disconnecting');
+    try {
+      await integration.disconnect(activeCompany);
+      setStatus((prev) => ({ ...prev, [integration.key]: false }));
+    } catch (error) {
+      console.error("Disconnection failed:", error);
+    } finally {
+      setConnectionStatus('idle');
+      handleCloseDialog();
+    }
+  };
+
+  const openMenu = (event: React.MouseEvent<HTMLElement>, integration: IntegrationConfig) => {
+    setSelectedIntegration(integration);
+    setAnchorEl(event.currentTarget);
+  };
+
+  const closeMenu = () => {
+    setAnchorEl(null);
+  };
+
+  const openDialog = (type: 'connect' | 'disconnect' | 'info') => {
+    setDialogType(type);
+    setDialogOpen(true);
+    closeMenu();
+  };
+
+  const handleCloseDialog = () => {
+    setDialogOpen(false);
   };
 
   return (
-    <div style={{ padding: 20 }}>
-      <Typography variant="h4" gutterBottom sx={{ mb: 4, fontWeight: 'bold' }}>
-        {t('integrations')}
-      </Typography>
-      <Grid container spacing={4}>
+    <Box sx={{ p: 3 }}>
+      <Box mb={4}>
+        <Typography variant="h4" fontWeight={700} sx={{ color: '#2d3748', mb: 1 }}>
+          {t('integrations')}
+        </Typography>
+        <Typography variant="body1" sx={{ color: '#718096', maxWidth: 700 }}>
+          {t('integrationsDescription')}
+        </Typography>
+      </Box>
+
+      <Grid container spacing={3}>
         {integrations.map((integration) => {
-          const isConnected = status[integration.key];
+          const isConnected = status[integration.key] || false;
+
           return (
-            <Grid item xs={12} sm={6} md={4} key={integration.key}>
-              <Card
-                sx={{
-                  minWidth: 275,
-                  borderRadius: 4,
-                  boxShadow: 3,
-                  transition: 'transform 0.3s, box-shadow 0.3s',
-                  '&:hover': { transform: 'translateY(-5px)', boxShadow: 6 },
-                }}
-              >
-                <CardContent sx={{ textAlign: 'center' }}>
-                  <Avatar
-                    sx={{
-                      width: 80,
-                      height: 80,
-                      mb: 2,
-                      mx: 'auto',
-                      bgcolor: integration.color,
-                      color: 'white',
-                    }}
-                  >
-                    {integration.icon}
-                  </Avatar>
-                  <Typography variant="h5" component="div" sx={{ mb: 2 }}>
-                    {integration.name}
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {isConnected
-                      ? t('integration.connected')
-                      : t('integration.disconnected')}
-                  </Typography>
-                </CardContent>
-                <CardActions sx={{ justifyContent: 'center', pb: 3 }}>
-                  {isConnected ? (
-                    <Button
-                      variant="contained"
-                      color="error"
-                      onClick={() => handleDisconnect(integration)}
-                    >
-                      {t('integration.disconnect')}
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="contained"
-                      sx={{
-                        borderRadius: 2,
-                        bgcolor: integration.color,
-                        '&:hover': { bgcolor: `${integration.color}CC` },
-                      }}
-                      onClick={() => handleConnect(integration)}
-                    >
-                      {t('integration.connect')}
-                    </Button>
-                  )}
-                </CardActions>
-              </Card>
+            <Grid item xs={12} sm={6} md={4} lg={3} key={integration.key}>
+              <IntegrationCard
+                integration={integration}
+                isConnected={isConnected}
+                handleConnect={handleConnect}
+                handleDisconnect={handleDisconnect}
+                openMenu={openMenu}
+                t={t}
+              />
             </Grid>
           );
         })}
       </Grid>
-    </div>
+
+      {/* Context Menu */}
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={closeMenu}
+        transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+        anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+      >
+        <MenuItem onClick={() => openDialog('info')}>
+          <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 150 }}>
+            <FaInfoCircle style={{ marginRight: 10, color: '#578acd' }} />
+            <Typography>{t('integration.details')}</Typography>
+          </Box>
+        </MenuItem>
+        <Divider />
+        {status[selectedIntegration?.key || ''] ? (
+          <MenuItem onClick={() => openDialog('disconnect')}>
+            <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 150 }}>
+              <FaUnlink style={{ marginRight: 10, color: '#f44336' }} />
+              <Typography>{t('integration.disconnect')}</Typography>
+            </Box>
+          </MenuItem>
+        ) : (
+          <MenuItem onClick={() => openDialog('connect')}>
+            <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 150 }}>
+              <FaPlug style={{ marginRight: 10, color: '#4caf50' }} />
+              <Typography>{t('integration.connect')}</Typography>
+            </Box>
+          </MenuItem>
+        )}
+      </Menu>
+
+      {/* Confirmation Dialog */}
+      <Dialog open={dialogOpen} onClose={handleCloseDialog} maxWidth="sm" fullWidth>
+        <DialogTitle sx={{ borderBottom: '1px solid #eee', pb: 2 }}>
+          {dialogType === 'connect' && t('integration.confirmConnectTitle')}
+          {dialogType === 'disconnect' && t('integration.confirmDisconnectTitle')}
+          {dialogType === 'info' && t('integration.details')}
+        </DialogTitle>
+
+        <DialogContent sx={{ pt: 3 }}>
+          {selectedIntegration && (
+            <Box display="flex" alignItems="center" mb={3}>
+              <Avatar
+                sx={{
+                  width: 40,
+                  height: 40,
+                  mr: 2,
+                  bgcolor: selectedIntegration.color,
+                  color: 'white',
+                }}
+              >
+                {selectedIntegration.icon}
+              </Avatar>
+              <Typography variant="h6" fontWeight={600}>
+                {selectedIntegration.name}
+              </Typography>
+            </Box>
+          )}
+
+          {dialogType === 'connect' && (
+            <Typography>
+              {t('integration.confirmConnect', { integration: selectedIntegration?.name })}
+            </Typography>
+          )}
+
+          {dialogType === 'disconnect' && (
+            <Typography>
+              {t('integration.confirmDisconnect', { integration: selectedIntegration?.name })}
+            </Typography>
+          )}
+
+          {dialogType === 'info' && (
+            <Typography>
+              {t('integration.infoText', {
+                integration: selectedIntegration?.name,
+                status: status[selectedIntegration?.key || ''] ?
+                  t('integration.connected') : t('integration.disconnected')
+              })}
+            </Typography>
+          )}
+        </DialogContent>
+
+        <DialogActions sx={{ p: 2, borderTop: '1px solid #eee' }}>
+          <Button
+            onClick={handleCloseDialog}
+            variant="outlined"
+            sx={{ borderRadius: 2 }}
+          >
+            {t('integration.cancel')}
+          </Button>
+
+          {dialogType === 'connect' && (
+            <Button
+              variant="contained"
+              onClick={() => selectedIntegration && handleConnect(selectedIntegration)}
+              disabled={connectionStatus === 'connecting'}
+              sx={{
+                borderRadius: 2,
+                background: 'linear-gradient(45deg, #578acd 30%, #6a9bdf 90%)',
+                minWidth: 120,
+              }}
+            >
+              {connectionStatus === 'connecting' ?
+                t('integration.connecting') : t('integration.confirmConnect')
+              }
+            </Button>
+          )}
+
+          {dialogType === 'disconnect' && (
+            <Button
+              variant="contained"
+              color="error"
+              onClick={() => selectedIntegration && handleDisconnect(selectedIntegration)}
+              disabled={connectionStatus === 'disconnecting'}
+              sx={{ borderRadius: 2, minWidth: 120 }}
+            >
+              {connectionStatus === 'disconnecting' ?
+                t('integration.disconnecting') : t('integration.confirmDisconnect')
+              }
+            </Button>
+          )}
+        </DialogActions>
+      </Dialog>
+    </Box>
   );
 };
 

--- a/src/components/integrations/index.tsx
+++ b/src/components/integrations/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Grid,
   Card,
@@ -7,175 +7,200 @@ import {
   CardActions,
   Button,
   Avatar,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
 } from '@mui/material';
-import { SiUbereats, SiWordpress, SiShopify } from 'react-icons/si';
-import ShopifyService from '../../services/shopify.service.ts';
+import { useTranslation } from 'react-i18next';
+import { FaFacebookF, FaInstagram, FaWhatsapp, FaLinkedinIn, FaTwitter, FaGoogle, FaYoutube, FaEnvelope } from 'react-icons/fa';
+import FacebookService from '../../services/facebook.service.ts';
+import InstagramService from '../../services/instagram.service.ts';
+import WhatsappService from '../../services/whatsapp.service.ts';
+import LinkedinService from '../../services/linkedin.service.ts';
+import TwitterService from '../../services/twitter.service.ts';
+import YouTubeService from '../../services/youtube.service.ts';
+import EmailService from '../../services/email.service.ts';
+import http from '../../services/http-business.ts';
 
-// Lista de integrações com dados básicos
-const integrations = [
+type IntegrationConfig = {
+  key: string;
+  name: string;
+  color: string;
+  icon: JSX.Element;
+  checkStatus: (companyId: string) => Promise<any>;
+  connect: (companyId: string) => Promise<any>;
+  disconnect: (companyId: string) => Promise<any>;
+};
+
+const integrations: IntegrationConfig[] = [
   {
-    name: 'Uber Eats',
-    description: 'Integre com o Uber Eats para gerenciamento de pedidos e entregas.',
-    icon: <SiUbereats size={40} />,
-    color: '#06C167',
+    key: 'facebook',
+    name: 'Facebook',
+    color: '#1877F2',
+    icon: <FaFacebookF size={40} />,
+    checkStatus: FacebookService.checkFacebookStatus,
+    connect: (companyId) => FacebookService.getAuthLink(companyId),
+    disconnect: (companyId) => http.delete(`/facebook/disconnect?companyId=${companyId}`),
   },
   {
-    name: 'WordPress',
-    description: 'Gerencie conteúdos do seu site e blog através do WordPress.',
-    icon: <SiWordpress size={40} />,
-    color: '#21759B',
+    key: 'instagram',
+    name: 'Instagram',
+    color: '#E1306C',
+    icon: <FaInstagram size={40} />,
+    checkStatus: InstagramService.checkInstagramStatus,
+    connect: (companyId) => InstagramService.getAuthLink(companyId),
+    disconnect: (companyId) => http.delete(`/instagram/disconnect?companyId=${companyId}`),
   },
   {
-    name: 'Shopify',
-    description: 'Sincronize sua loja online e gerencie produtos com o Shopify.',
-    icon: <SiShopify size={40} />,
-    color: '#7AB55C',
+    key: 'whatsapp',
+    name: 'WhatsApp',
+    color: '#25D366',
+    icon: <FaWhatsapp size={40} />,
+    checkStatus: WhatsappService.checkWhatsAppStatus,
+    connect: (companyId) => WhatsappService.getQrCode(companyId),
+    disconnect: (companyId) => http.delete(`/whatsapp/disconnect?companyId=${companyId}`),
+  },
+  {
+    key: 'linkedin',
+    name: 'LinkedIn',
+    color: '#0A66C2',
+    icon: <FaLinkedinIn size={40} />,
+    checkStatus: LinkedinService.checkLinkedinStatus,
+    connect: (companyId) => LinkedinService.getAuthLink(companyId),
+    disconnect: (companyId) => http.delete(`/linkedin/disconnect?companyId=${companyId}`),
+  },
+  {
+    key: 'twitter',
+    name: 'Twitter',
+    color: '#1DA1F2',
+    icon: <FaTwitter size={40} />,
+    checkStatus: TwitterService.checkTwitterStatus,
+    connect: (companyId) => TwitterService.getAuthLink(companyId),
+    disconnect: (companyId) => http.delete(`/twitter/disconnect?companyId=${companyId}`),
+  },
+  {
+    key: 'google',
+    name: 'Google',
+    color: '#4285F4',
+    icon: <FaGoogle size={40} />,
+    checkStatus: (companyId) => http.get(`/google/status?companyId=${companyId}`),
+    connect: (companyId) => http.get(`/google/auth-link?companyId=${companyId}`),
+    disconnect: (companyId) => http.delete(`/google/disconnect?companyId=${companyId}`),
+  },
+  {
+    key: 'youtube',
+    name: 'YouTube',
+    color: '#FF0000',
+    icon: <FaYoutube size={40} />,
+    checkStatus: YouTubeService.checkYoutubeStatus,
+    connect: (companyId) => YouTubeService.getAuthLink(companyId),
+    disconnect: (companyId) => http.delete(`/youtube/disconnect?companyId=${companyId}`),
+  },
+  {
+    key: 'email',
+    name: 'Email',
+    color: '#555555',
+    icon: <FaEnvelope size={40} />,
+    checkStatus: (companyId) => EmailService.getAccount(companyId),
+    connect: (companyId) => EmailService.createAccount({ companyId }),
+    disconnect: (companyId) => http.delete(`/email/disconnect?companyId=${companyId}`),
   },
 ];
 
-// Componente para renderizar cada card de integração
-const IntegrationCard = ({ integration, onConnect }) => (
-  <Card
-    sx={{
-      minWidth: 275,
-      borderRadius: 4,
-      boxShadow: 3,
-      transition: 'transform 0.3s, box-shadow 0.3s',
-      '&:hover': {
-        transform: 'translateY(-5px)',
-        boxShadow: 6,
-      },
-    }}
-  >
-    <CardContent sx={{ textAlign: 'center' }}>
-      <Avatar
-        sx={{
-          width: 80,
-          height: 80,
-          mb: 2,
-          mx: 'auto',
-          bgcolor: integration.color,
-          color: 'white',
-        }}
-      >
-        {integration.icon}
-      </Avatar>
-      <Typography variant="h5" component="div" sx={{ mb: 2 }}>
-        {integration.name}
-      </Typography>
-      <Typography variant="body2" color="text.secondary">
-        {integration.description}
-      </Typography>
-    </CardContent>
-    <CardActions sx={{ justifyContent: 'center', pb: 3 }}>
-      <Button
-        variant="contained"
-        size="medium"
-        sx={{
-          borderRadius: 2,
-          bgcolor: integration.color,
-          '&:hover': {
-            bgcolor: `${integration.color}CC`,
-          },
-        }}
-        onClick={() => onConnect(integration)}
-      >
-        Connect
-      </Button>
-    </CardActions>
-  </Card>
-);
+const Integrations: React.FC<{ activeCompany: string }> = ({ activeCompany }) => {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<Record<string, boolean>>({});
 
-// Modal para integração com o Shopify
-const ShopifyIntegrationModal = ({ open, onClose, companyId }) => {
-  const [shopDomain, setShopDomain] = useState('');
+  useEffect(() => {
+    if (!activeCompany) return;
+    integrations.forEach(async (integration) => {
+      try {
+        const result = await integration.checkStatus(activeCompany);
+        setStatus((prev) => ({ ...prev, [integration.key]: !!result }));
+      } catch (err) {
+        setStatus((prev) => ({ ...prev, [integration.key]: false }));
+      }
+    });
+  }, [activeCompany]);
 
-  const handleConnect = async () => {
-    try {
-      // Chama o service para gerar o link de autenticação
-      const response = await ShopifyService.getAuthLink(companyId, shopDomain);
-      // Redireciona para o link de OAuth do Shopify
+  const handleConnect = async (integration: IntegrationConfig) => {
+    const response = await integration.connect(activeCompany);
+    if (response?.data) {
       window.location.href = response.data;
-    } catch (error) {
-      console.error('Erro ao conectar o Shopify:', error);
-      alert('Erro ao iniciar integração com Shopify. Tente novamente.');
     }
   };
 
-  return (
-    <Dialog open={open} onClose={onClose}>
-      <DialogTitle>Integrar Shopify</DialogTitle>
-      <DialogContent>
-        <Typography variant="body2" sx={{ mb: 2 }}>
-          Insira o domínio da sua loja (ex.: minhaloja.myshopify.com) para iniciar a integração.
-        </Typography>
-        <TextField
-          label="Domínio da Loja"
-          value={shopDomain}
-          onChange={(e) => setShopDomain(e.target.value)}
-          fullWidth
-          variant="outlined"
-        />
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancelar</Button>
-        <Button variant="contained" onClick={handleConnect}>
-          Conectar
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-};
-
-// Tela principal de integrações
-const Integrations = () => {
-  const [shopifyModalOpen, setShopifyModalOpen] = useState(false);
-  const companyId = 'empresa-123'; // Exemplo: você pode obter esse valor do contexto/auth
-
-  // Função chamada quando o usuário clica em "Connect"
-  const handleConnect = async (integration) => {
-    if (integration.name === 'Shopify') {
-      try {
-        // Verifica o status no backend
-        const statusResponse = await ShopifyService.checkShopifyStatus(companyId);
-        if (!statusResponse) {
-          // Se não estiver integrado, abre o modal para integração
-          setShopifyModalOpen(true);
-        } else {
-          alert('Shopify já está integrado.');
-        }
-      } catch (error) {
-        console.error('Erro ao verificar integração do Shopify:', error);
-        alert('Erro ao verificar integração. Tente novamente.');
-      }
-    } else {
-      // Outras integrações podem seguir outros fluxos
-      alert(`Integração com ${integration.name} não implementada neste exemplo.`);
-    }
+  const handleDisconnect = async (integration: IntegrationConfig) => {
+    await integration.disconnect(activeCompany);
+    setStatus((prev) => ({ ...prev, [integration.key]: false }));
   };
 
   return (
     <div style={{ padding: 20 }}>
       <Typography variant="h4" gutterBottom sx={{ mb: 4, fontWeight: 'bold' }}>
-        Integrações
+        {t('integrations')}
       </Typography>
       <Grid container spacing={4}>
-        {integrations.map((integration, index) => (
-          <Grid item xs={12} sm={6} md={4} key={index}>
-            <IntegrationCard integration={integration} onConnect={handleConnect} />
-          </Grid>
-        ))}
+        {integrations.map((integration) => {
+          const isConnected = status[integration.key];
+          return (
+            <Grid item xs={12} sm={6} md={4} key={integration.key}>
+              <Card
+                sx={{
+                  minWidth: 275,
+                  borderRadius: 4,
+                  boxShadow: 3,
+                  transition: 'transform 0.3s, box-shadow 0.3s',
+                  '&:hover': { transform: 'translateY(-5px)', boxShadow: 6 },
+                }}
+              >
+                <CardContent sx={{ textAlign: 'center' }}>
+                  <Avatar
+                    sx={{
+                      width: 80,
+                      height: 80,
+                      mb: 2,
+                      mx: 'auto',
+                      bgcolor: integration.color,
+                      color: 'white',
+                    }}
+                  >
+                    {integration.icon}
+                  </Avatar>
+                  <Typography variant="h5" component="div" sx={{ mb: 2 }}>
+                    {integration.name}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {isConnected
+                      ? t('integration.connected')
+                      : t('integration.disconnected')}
+                  </Typography>
+                </CardContent>
+                <CardActions sx={{ justifyContent: 'center', pb: 3 }}>
+                  {isConnected ? (
+                    <Button
+                      variant="contained"
+                      color="error"
+                      onClick={() => handleDisconnect(integration)}
+                    >
+                      {t('integration.disconnect')}
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="contained"
+                      sx={{
+                        borderRadius: 2,
+                        bgcolor: integration.color,
+                        '&:hover': { bgcolor: `${integration.color}CC` },
+                      }}
+                      onClick={() => handleConnect(integration)}
+                    >
+                      {t('integration.connect')}
+                    </Button>
+                  )}
+                </CardActions>
+              </Card>
+            </Grid>
+          );
+        })}
       </Grid>
-      <ShopifyIntegrationModal
-        open={shopifyModalOpen}
-        onClose={() => setShopifyModalOpen(false)}
-        companyId={companyId}
-      />
     </div>
   );
 };

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -189,11 +189,11 @@ const Sidebar: React.FC<{
         ))}
       </SidebarContainerBody>
       <SidebarContainerFooter>
-        <SidebarContainerBodyElement
+        {/* <SidebarContainerBodyElement
           style={{ marginLeft: '6%', marginBottom:'17px', fontSize:'13pt' }}
         >
           {t(`notifications`)}
-        </SidebarContainerBodyElement>
+        </SidebarContainerBodyElement> */}
         <SidebarContainerBodyElement
           onClick={() => {
             if (window.outerWidth < 600) {

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -199,6 +199,17 @@ const Sidebar: React.FC<{
             if (window.outerWidth < 600) {
               props.setIsMenuActive(!props.isMenuActive);
             }
+            props.activateModule('integration');
+          }}
+          style={{ marginLeft: '6%', marginBottom:'17px', fontSize:'13pt' }}
+        >
+          {t('integrations')}
+        </SidebarContainerBodyElement>
+        <SidebarContainerBodyElement
+          onClick={() => {
+            if (window.outerWidth < 600) {
+              props.setIsMenuActive(!props.isMenuActive);
+            }
             props.activateModule('config');
           }}
           style={{ marginLeft: '6%', marginBottom:'17px', fontSize:'13pt' }}

--- a/src/components/sidebar/mobile/index.tsx
+++ b/src/components/sidebar/mobile/index.tsx
@@ -309,7 +309,7 @@ const MobileBottomNavigation = ({
           </Tooltip>
         )}
 
-          {[{ key: 'config', icon: RiSettingsLine, label: t('configurations') }, { key: 'logout', icon: IoMdLogOut, label: t('logout') }].map(item => (
+          {[{ key: 'integration', icon: CgExtension, label: t('integrations') }, { key: 'config', icon: RiSettingsLine, label: t('configurations') }, { key: 'logout', icon: IoMdLogOut, label: t('logout') }].map(item => (
             <Tooltip key={item?.key} title={item.label} placement="top" arrow>
               <NavItem onClick={() => handleItemClick(item?.key)} active={activeItem === item?.key}>
                 <ActiveIndicator active={activeItem === item?.key} />

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -236,6 +236,12 @@
   },
   "notifications": "Notifications",
   "integrations": "Integrations",
+  "integration": {
+    "connect": "Connect",
+    "disconnect": "Disconnect",
+    "connected": "Connected",
+    "disconnected": "Disconnected"
+  },
   "ads": {
     "title": "Ads Management",
     "subtitle": "Create, manage and optimize campaigns across platforms",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -242,6 +242,12 @@
   },
   "notifications": "Notificações",
   "integrations": "Integrações",
+  "integration": {
+    "connect": "Conectar",
+    "disconnect": "Desconectar",
+    "connected": "Conectado",
+    "disconnected": "Desconectado"
+  },
   "ads": {
     "title": "Gerenciamento de Anúncios",
     "subtitle": "Crie, gerencie e otimize campanhas em várias plataformas",

--- a/src/pages/Dashboard/dashboard.tsx
+++ b/src/pages/Dashboard/dashboard.tsx
@@ -140,7 +140,7 @@ useEffect(() => {
             setActiveCompany={changeActiveCompany}
           />
         ) : ''}
-        {activeModuleName === 'integration' && <Integrations />}
+        {activeModuleName === 'integration' && <Integrations activeCompany={activeCompany} />}
       </DashboardContainerShowed>
     </DashboardContainer>
   );


### PR DESCRIPTION
## Summary
- add integrations module with connect/disconnect cards
- expose integrations access in sidebar and mobile bottom nav
- add translations for integration labels

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: peer dependency conflict @mui/lab)*

------
https://chatgpt.com/codex/tasks/task_e_688e11d376b48321b9e25bef9368e8ba