### PR TITLE
Fix integration description and open links in new tab

### DIFF
--- a/src/components/integrations/index.tsx
+++ b/src/components/integrations/index.tsx
@@ -281,7 +281,7 @@ const Integrations: React.FC<{ activeCompany: string }> = ({ activeCompany }) =>
     try {
       const response = await integration.connect(activeCompany);
       if (response?.data) {
-        window.location.href = response.data;
+        window.open(response.data, '_blank');
       }
     } catch (error) {
       console.error("Connection failed:", error);

--- a/src/data/en.json
+++ b/src/data/en.json
@@ -236,6 +236,7 @@
   },
   "notifications": "Notifications",
   "integrations": "Integrations",
+  "integrationsDescription": "Manage and easily connect your favorite platforms.",
   "integration": {
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/src/data/pt.json
+++ b/src/data/pt.json
@@ -242,6 +242,7 @@
   },
   "notifications": "Notificações",
   "integrations": "Integrações",
+  "integrationsDescription": "Gerencie e conecte facilmente suas plataformas favoritas.",
   "integration": {
     "connect": "Conectar",
     "disconnect": "Desconectar",


### PR DESCRIPTION
## Summary
- add translation for integrations page description
- open backend-provided integration link in a new browser tab

## Testing
- `CI=true npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688eb0a561608321970bed4a9398ba28